### PR TITLE
Mop classic update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Package and release
       uses: BigWigsMods/packager@v2
       with:
-        args: -n ":{package-name}-{project-version}{classic}"
+        args: -n "{package-name}-{project-version}{classic}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+settings.json

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -3,8 +3,19 @@ package-as: SimpleTradeSkillExporter
 move-folders:
     SimpleTradeSkillExporter/SimpleTradeSkillExporter: SimpleTradeSkillExporter
 
-ignore:
-  - README.md
-  - LICENSE
+manual-changelog:
+    filename: CHANGELOG.md
+    markup-type: markdown
 
-changelog-title: SimpleTradeSkillExporter
+ignore:
+    - .github
+    - .vscode
+    - .luacheckrc
+    - .luarc.json
+    - .editorconfig
+    - .stylua.toml
+    - .gitignore
+    - README.md
+    - CHANGELOG.md
+    - LICENSE
+    - tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# 1.0.4
+- Add support for Wago release
+- Add space between Addon Title & Version
+
+# 1.0.3
+- Add support for Wago release
+- Add space between Addon Title & Version
+
+# 1.0.2
+- Update TOC for MoP Classic 1048094, added loading message.
+
+# 1.0.1
+- Update TOC for correct Cataclysm Version 40400
+
+# 1.0.0
+- Initial support for exporting to basic text, comma separated values and markdown text.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # 1.0.4
-- Add support for Wago release
-- Add space between Addon Title & Version
+Updates SimpleTradeSkillExporter to support Mists of Pandaria Classic (5.5.x).
+
+### Changes
+
+- **Interface version** bumped from `40400` (Cataclysm) to `50503` (MoP Classic 5.5.x)
+- **Wowhead URLs** updated from `/cata/` to `/mop-classic/` for CSV and Markdown exports
+- **Load notification** added — prints a confirmation message to chat on login with a hint to type `/tsexport help`
 
 # 1.0.3
 - Add support for Wago release

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
@@ -1,3 +1,12 @@
+local loadedFrame = CreateFrame("Frame")
+loadedFrame:RegisterEvent("ADDON_LOADED")
+loadedFrame:SetScript("OnEvent", function(self, event, addonName)
+	if addonName == "SimpleTradeSkillExporter" then
+		print("\124cff00FF00SimpleTradeSkillExporter\124r loaded. Type \124cff00FF00/tsexport help\124r for usage.")
+		self:UnregisterEvent("ADDON_LOADED")
+	end
+end)
+
 SLASH_SIMPLETRADESKILLEXPORTER1 = "/tsexport"
 SlashCmdList["SIMPLETRADESKILLEXPORTER"] = function(msg)
 	if msg == "help" then
@@ -20,10 +29,10 @@ SlashCmdList["SIMPLETRADESKILLEXPORTER"] = function(msg)
 					local itemLink = getItemLink(i)
 					if itemLink then
 						if msg == "csv" then
-							text = text .. '=HYPERLINK("https://wowhead.com/cata/' .. itemLink .. '";"' .. name .. '")\n'
+							text = text .. '=HYPERLINK("https://wowhead.com/mop-classic/' .. itemLink .. '";"' .. name .. '")\n'
 						elseif msg == "markdown" then
 							text = text ..
-							"- " .. "[" .. name .. "]" .. "(" .. "https://wowhead.com/cata/" .. itemLink .. ")" .. '\n'
+							"- " .. "[" .. name .. "]" .. "(" .. "https://wowhead.com/mop-classic/" .. itemLink .. ")" .. '\n'
 						else
 							text = text .. name .. "\n"
 						end

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.toc
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.toc
@@ -1,4 +1,4 @@
-## Interface: 40400
+## Interface: 50503
 ## Title: SimpleTradeSkillExporter |cFF00FF00@project-version@|r
 ## Author: Hamma / GrumpyOldLisian
 ## Notes: A simple trade skill exporter


### PR DESCRIPTION
## Mists of Pandaria Classic Support

Updates SimpleTradeSkillExporter to support Mists of Pandaria Classic (5.5.x).

### Changes

- **Interface version** bumped from `40400` (Cataclysm) to `50503` (MoP Classic 5.5.x)
- **Wowhead URLs** updated from `/cata/` to `/mop-classic/` for CSV and Markdown exports
- **Load notification** added — prints a confirmation message to chat on login with a hint to type `/tsexport help`
- **Package name format** fixed — removed leading `:` from the packager `args` string
- **`.pkgmeta`** expanded to include `manual-changelog` and a full ignore list covering dev/config files
- **`.gitignore`** updated to exclude `settings.json`
