### PR TITLE
Add SimpleGuildRosterExporter with multi-client support and shared addon library updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Package and Release
 on:
   push:
     tags:
-      - "trade-v*"
-      - "guild-v*"
+      - "tse-v*"
+      - "gre-v*"
       - "!**-alpha**"
       - "!**-beta**"
 
@@ -23,7 +23,7 @@ jobs:
 
   release-trade:
     runs-on: ubuntu-latest
-    if: always() && needs.lint.result != 'cancelled' && startsWith(github.ref_name, 'trade-')
+    if: always() && needs.lint.result != 'cancelled' && startsWith(github.ref_name, 'tse-')
     needs: lint
     env:
       CF_API_KEY: ${{ secrets.CF_API_KEY }}
@@ -43,7 +43,7 @@ jobs:
 
   release-guild:
     runs-on: ubuntu-latest
-    if: always() && needs.lint.result != 'cancelled' && startsWith(github.ref_name, 'guild-')
+    if: always() && needs.lint.result != 'cancelled' && startsWith(github.ref_name, 'gre-')
     needs: lint
     env:
       CF_API_KEY: ${{ secrets.CF_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create clean version tag
-        run: |
-          git tag -d "${GITHUB_REF_NAME}"
-          git tag "${GITHUB_REF_NAME#trade-}"
-
       - name: Package and release
         uses: BigWigsMods/packager@v2
         with:
@@ -60,11 +55,6 @@ jobs:
   #       uses: actions/checkout@v4.2.2
   #       with:
   #         fetch-depth: 0
-
-  #     - name: Create clean version tag
-  #       run: |
-  #         git tag -d "${GITHUB_REF_NAME}"
-  #         git tag "${GITHUB_REF_NAME#guild-}"
 
   #     - name: Package and release
   #       uses: BigWigsMods/packager@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,23 +41,22 @@ jobs:
         with:
           args: -m .pkgmeta-trade -n "{package-name}-{project-version}{classic}"
 
-  # release-guild:
-  #   runs-on: ubuntu-latest
-  #   if: always() && needs.lint.result != 'cancelled' && startsWith(github.ref_name, 'guild-')
-  #   needs: lint
-  #   env:
-  #     CF_API_KEY: ${{ secrets.CF_API_KEY }}
-  #     WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
-  #     GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+  release-guild:
+    runs-on: ubuntu-latest
+    if: always() && needs.lint.result != 'cancelled' && startsWith(github.ref_name, 'guild-')
+    needs: lint
+    env:
+      CF_API_KEY: ${{ secrets.CF_API_KEY }}
+      WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
 
-  #   steps:
-  #     - name: Clone project
-  #       uses: actions/checkout@v4.2.2
-  #       with:
-  #         fetch-depth: 0
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
 
-  #     - name: Package and release
-  #       uses: BigWigsMods/packager@v2
-  #       with:
-  #         args: -m .pkgmeta-guild -n "{package-name}-{project-version}{classic}"
-
+      - name: Package and release
+        uses: BigWigsMods/packager@v2
+        with:
+          args: -m .pkgmeta-guild -n "{package-name}-{project-version}{classic}"

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,7 +6,10 @@ ignore = {
 }
 globals = {
     'SLASH_SIMPLETRADESKILLEXPORTER1',
+    'SLASH_SIMPLEGUILDROSTEREXPORTER1',
+    'SLASH_SIMPLEWOWEXPORTERS1',
     'SlashCmdList',
+    '_G',
 }
 read_globals = {
     'ABANDON_PET',
@@ -22324,6 +22327,10 @@ read_globals = {
     'TradeSkillFilter_OnTextChanged',
     'TradeSkillFrame',
     'TradeSkillFramePortrait',
+    'GuildFrame',
+    'GuildFramePortrait',
+    'GuildRoster',
+    'GRM_RosterTab',
     C_AddOns = {
         fields = {
             'DisableAddOn',

--- a/.pkgmeta-guild
+++ b/.pkgmeta-guild
@@ -9,6 +9,8 @@ manual-changelog:
     markup-type: markdown
 
 ignore:
+    - SimpleTradeSkillExporter
+    - tools
     - .github
     - .vscode
     - .luacheckrc

--- a/.pkgmeta-trade
+++ b/.pkgmeta-trade
@@ -9,6 +9,8 @@ manual-changelog:
     markup-type: markdown
 
 ignore:
+    - SimpleGuildRosterExporter
+    - tools
     - .github
     - .vscode
     - .luacheckrc

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple World of Warcraft exporters is a suite of focused addons that make it eas
 
 ## SimpleTradeSkillExporter
 
-Simple Trade Skill Exporter is an addon which allows you to export your learned trade skill recipes. It supports all professions and triggered via the tradeskill window or slash commands. You can export your recipes as plain text, Markdown With Wowhead links, or CSV with Wowhead links. Originally inspired by TradeSkillExporter, created with permission from GrumpyOldLisian. Part of the *SimpleWowExporter* collection of addons.
+Simple Trade Skill Exporter is an addon which allows you to export your learned trade skill recipes. It supports all professions and triggered via the tradeskill window or slash commands. You can export your recipes as plain text, Markdown With Wowhead links, or CSV with Wowhead links. Originally inspired by TradeSkillExporter, created with permission from GrumpyOldLisian. Part of the *SimpleWowExporters* collection of addons.
 
 ### Supported Versions
 
@@ -38,7 +38,7 @@ Use the **Select All** button or CTRL-A, then CTRL-C to copy the output and past
 
 ## SimpleGuildRosterExporter
 
-Simple Guild Roster Exporter allows you to export your guild roster to plain text, CSV, Markdown list, or Markdown table format. Part of the *SimpleWowExporter* collection of addons.
+Simple Guild Roster Exporter allows you to export your guild roster to plain text, CSV, Markdown list, or Markdown table format. Part of the *SimpleWowExporters* collection of addons.
 
 ### Supported Versions
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple World of Warcraft exporters is a suite of focused addons that make it eas
 
 ## SimpleTradeSkillExporter
 
-Simple Trade Skill Exporter is an addon which allows you to export your learned trade skill recipes. It supports all professions and triggered via the tradeskill window or slash commands. You can export your recipes as plain text, Markdown With Wowhead links, or CSV with Wowhead links. Originally inspired by TradeSkillExporter, created with permission from GrumpyOldLisian.
+Simple Trade Skill Exporter is an addon which allows you to export your learned trade skill recipes. It supports all professions and triggered via the tradeskill window or slash commands. You can export your recipes as plain text, Markdown With Wowhead links, or CSV with Wowhead links. Originally inspired by TradeSkillExporter, created with permission from GrumpyOldLisian. Part of the *SimpleWowExporter* collection of addons.
 
 ### Supported Versions
 
@@ -38,7 +38,7 @@ Use the **Select All** button or CTRL-A, then CTRL-C to copy the output and past
 
 ## SimpleGuildRosterExporter
 
-Simple Guild Roster Exporter allows you to export your guild roster to plain text, CSV, Markdown list, or Markdown table format.
+Simple Guild Roster Exporter allows you to export your guild roster to plain text, CSV, Markdown list, or Markdown table format. Part of the *SimpleWowExporter* collection of addons.
 
 ### Supported Versions
 

--- a/README.md
+++ b/README.md
@@ -33,3 +33,36 @@ Use the **Select All** button or CTRL-A, then CTRL-C to copy the output and past
 | `/tsexport csv` | CSV with Wowhead hyperlinks — all expansions |
 | `/tsexport csv current` | CSV with Wowhead hyperlinks — current expansion only |
 | `/tsexport help` | Show available commands |
+
+---
+
+## SimpleGuildRosterExporter
+
+Simple Guild Roster Exporter allows you to export your guild roster to plain text, CSV, Markdown list, or Markdown table format.
+
+### Supported Versions
+
+- Retail (The War Within / Midnight)
+- Mists of Pandaria Classic
+- Cataclysm Classic
+- Wrath of the Lich King Classic
+- The Burning Crusade Classic (Anniversary)
+- Classic Era (Vanilla)
+
+### Usage
+
+Open the guild frame, then either use `/grexport` or click the export button. On classic clients (Vanilla through Cataclysm) this is a **GRExport** button in the title bar. On MoP Classic and Retail, it appears as an icon tab on the right side panel of the guild frame.
+
+The export window opens with format controls built in — switch between Text, CSV, Markdown List, and Markdown Table without reopening.
+
+Use the **Select All** button or CTRL-A, then CTRL-C to copy the output and paste it wherever you need it.
+
+### Slash Commands
+
+| Command | Output |
+|---------|--------|
+| `/grexport` | Plain text — all members |
+| `/grexport csv` | CSV — all members |
+| `/grexport markdown list` | Markdown list — name, level, class |
+| `/grexport markdown table` | Markdown table — all fields |
+| `/grexport help` | Show available commands |

--- a/Shared/SimpleWowExportersLib.lua
+++ b/Shared/SimpleWowExportersLib.lua
@@ -2,7 +2,7 @@
 -- Author: Hamma
 -- Shared export window UI and row/header renderer for Simple*Exporter addons.
 -- Loaded by each addon's TOC before the addon's own Lua file.
--- Attached to the addon namespace (ns.SWE) — no globals written.
+-- Attached to the addon namespace (ns.SWE) — also writes _G.SWERegistry for cross-addon coordination.
 --
 -- Public API:
 --
@@ -11,7 +11,7 @@
 --     format: "text" | "csv" | "markdown" | "md-table"
 --     values: array of strings or {label=string, url=string} tables.
 --     Values with a url are rendered as hyperlinks where the format supports it.
---     Text joins values with tabs. CSV quotes values. Markdown renders values[1]
+--     Text joins values with two spaces. CSV quotes values. Markdown renders values[1]
 --     as a list item. md-table renders all values as a pipe-separated row.
 --
 --   SWE.RenderHeader(format, columns) -> string
@@ -25,9 +25,10 @@
 --     The window has format toggle buttons, an optional scope checkbox,
 --     a scrollable edit box, and Select All / Close buttons.
 --     config: {
---       buttons       = { {label, value, disabled}, ... },
+--       buttons       = { {label, value, width, disabled}, ... },  -- width in pixels (default 72)
 --       defaultFormat = string,
 --       hasScope      = bool,
+--       scopeLabel    = string,           -- checkbox label (default "All expansions")
 --       onRefresh     = function(format, scope) -> text, title
 --     }
 --     Call frame:Open(format, scope) to set state and show the window.

--- a/Shared/SimpleWowExportersLib.lua
+++ b/Shared/SimpleWowExportersLib.lua
@@ -31,10 +31,47 @@
 --       onRefresh     = function(format, scope) -> text, title
 --     }
 --     Call frame:Open(format, scope) to set state and show the window.
+--
+--   SWE.RegisterAddon(name, version, helpCommand)
+--     Registers an addon with the suite. Prints a combined load message listing
+--     all loaded addons after a short delay, and registers /swexport help to
+--     show help hints for all loaded addons.
 
 local _, ns = ...
 ns.SWE = {}
 local SWE = ns.SWE
+
+-- Shared registry across all addon instances — uses a global so both lib copies can coordinate.
+_G.SWERegistry = _G.SWERegistry or { addons = {}, slashRegistered = false, loadTimer = nil }
+
+-- SWE.RegisterAddon(name, version, helpCommand)
+-- Call from each addon's ADDON_LOADED handler instead of printing a load message directly.
+function SWE.RegisterAddon(name, version, helpCommand)
+	table.insert(_G.SWERegistry.addons, { name = name, version = version, helpCommand = helpCommand })
+
+	if not _G.SWERegistry.slashRegistered then
+		_G.SWERegistry.slashRegistered = true
+		SLASH_SIMPLEWOWEXPORTERS1 = "/swexport"
+		SlashCmdList["SIMPLEWOWEXPORTERS"] = function(msg)
+			print("\124cff00FF00SimpleWowExporters - Help\124r")
+			for _, addon in ipairs(_G.SWERegistry.addons) do
+				print("\124cff00FF00" .. addon.name .. ":\124r Type '" .. addon.helpCommand .. "' for commands.")
+			end
+		end
+	end
+
+	if _G.SWERegistry.loadTimer then
+		_G.SWERegistry.loadTimer:Cancel()
+	end
+	_G.SWERegistry.loadTimer = C_Timer.NewTimer(0.5, function()
+		local names = {}
+		for _, addon in ipairs(_G.SWERegistry.addons) do
+			table.insert(names, addon.name .. (addon.version and " \124cff00FF00v" .. addon.version .. "\124r" or ""))
+		end
+		print("\124cff00FF00SimpleWowExporters\124r loaded: " .. table.concat(names, ", ") .. ". Type \124cff00FF00/swexport help\124r for commands.")
+		_G.SWERegistry.loadTimer = nil
+	end)
+end
 
 -- SWE.RenderRow(format, values) -> string
 -- format: "text" | "csv" | "markdown" | "md-table"
@@ -84,7 +121,7 @@ function SWE.RenderRow(format, values)
 		for _, v in ipairs(values) do
 			table.insert(parts, type(v) == "table" and v.label or tostring(v))
 		end
-		return table.concat(parts, "\t") .. "\n"
+		return table.concat(parts, "  ") .. "\n"
 	end
 end
 
@@ -165,7 +202,7 @@ function SWE.CreateExportWindow(config)
 	frame.formatButtons = {}
 	for i, btnCfg in ipairs(config.buttons) do
 		local btn = CreateFrame("Button", nil, frame, "UIPanelButtonTemplate")
-		btn:SetSize(72, 22)
+		btn:SetSize(btnCfg.width or 72, 22)
 		btn:SetText(btnCfg.label)
 		btn.value = btnCfg.value
 
@@ -193,7 +230,7 @@ function SWE.CreateExportWindow(config)
 		local cb = CreateFrame("CheckButton", nil, frame, "UICheckButtonTemplate")
 		cb:SetPoint("LEFT", frame.formatButtons[#frame.formatButtons], "RIGHT", 10, 0)
 		cb:SetChecked(false)
-		cb.text:SetText("All expansions")
+		cb.text:SetText(config.scopeLabel or "All expansions")
 		cb:SetScript("OnClick", function()
 			selectedScope = cb:GetChecked()
 			frame.refresh()

--- a/Shared/SimpleWowExportersLib.lua
+++ b/Shared/SimpleWowExportersLib.lua
@@ -67,7 +67,8 @@ function SWE.RegisterAddon(name, version, helpCommand)
 	_G.SWERegistry.loadTimer = C_Timer.NewTimer(0.5, function()
 		local names = {}
 		for _, addon in ipairs(_G.SWERegistry.addons) do
-			table.insert(names, addon.name .. (addon.version and " \124cff00FF00v" .. addon.version .. "\124r" or ""))
+			local ver = addon.version and addon.version:match("v%d+%.%d+%.%d+")
+			table.insert(names, addon.name .. (ver and " \124cff00FF00" .. ver .. "\124r" or ""))
 		end
 		print("\124cff00FF00SimpleWowExporters\124r loaded: " .. table.concat(names, ", ") .. ". Type \124cff00FF00/swexport help\124r for commands.")
 		_G.SWERegistry.loadTimer = nil
@@ -78,7 +79,7 @@ end
 -- format: "text" | "csv" | "markdown" | "md-table"
 -- values: array of strings or {label=string, url=string} tables
 -- For "markdown": only values[1] is used (list format).
--- For "text": values are joined with tab.
+-- For "text": values are joined with two spaces.
 -- For "csv": values are quoted; {label,url} entries become =HYPERLINK(...).
 -- For "md-table": values are pipe-separated; {label,url} entries become [label](url).
 function SWE.RenderRow(format, values)

--- a/SimpleGuildRosterExporter-CHANGELOG.md
+++ b/SimpleGuildRosterExporter-CHANGELOG.md
@@ -1,0 +1,10 @@
+# 1.0.0
+Initial release of SimpleGuildRosterExporter.
+
+- Export guild roster data to plain text, CSV, Markdown list, or Markdown table
+- Includes all members (online and offline) with accurate last online duration
+- Toggle offline members via the "Include offline" checkbox in the export window
+- GRExport button on the guild frame for classic clients; icon tab on the right side panel for MoP Classic and Retail
+- /grexport slash command with format options
+- Combined load message with other Simple WoW Exporters addons
+- /swexport help lists commands across all loaded Simple WoW Exporters addons

--- a/SimpleGuildRosterExporter/SimpleGuildRosterExporter.lua
+++ b/SimpleGuildRosterExporter/SimpleGuildRosterExporter.lua
@@ -300,8 +300,7 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1)
 	if event == "ADDON_LOADED" and arg1 == addonName then
 		if not gre.SWE then
 			print("\124cffFF0000[GRE] Error:\124r SimpleWowExportersLib failed to load. Ensure SimpleWowExportersLib.lua is in the addon folder.")
-			self:UnregisterEvent("ADDON_LOADED")
-			self:UnregisterEvent("GUILD_ROSTER_UPDATE")
+			self:UnregisterAllEvents()
 			return
 		end
 		local version = getAddonMetadata and getAddonMetadata(addonName, "Version")

--- a/SimpleGuildRosterExporter/SimpleGuildRosterExporter.lua
+++ b/SimpleGuildRosterExporter/SimpleGuildRosterExporter.lua
@@ -1,0 +1,207 @@
+-- SimpleGuildRosterExporter
+-- Author: Hamma
+-- Description: Exports guild roster data to plain text, CSV, Markdown list, or Markdown table format.
+--              Supports all classic WoW flavors (Vanilla, TBC, Wrath, Cata, MoP).
+--              Use /grexport or the GRExport button on the guild frame.
+
+local addonName, gre = ...
+local SWE = gre.SWE  -- loaded by SimpleWowExportersLib.lua via TOC
+
+local exportWindow
+local pendingFormat = nil
+
+-- GuildRoster() is the classic API; C_GuildInfo.GuildRoster() is the retail-based client API (e.g. Anniversary)
+local requestRoster = (C_GuildInfo and C_GuildInfo.GuildRoster) or GuildRoster
+
+local validFormats = { text = true, csv = true, ["markdown-list"] = true, ["markdown-table"] = true }
+
+-- Translates GRE format values to the lib's internal format keys.
+local function libFormat(format)
+	if format == "markdown-list"  then return "markdown" end
+	if format == "markdown-table" then return "md-table" end
+	return format
+end
+
+-- Examples: "csv" -> "csv", "markdown list" -> "markdown-list", "" -> "text", "foo" -> "text" + warning
+local function parseCommand(msg)
+	local parts = {}
+	for part in msg:gmatch("%S+") do table.insert(parts, part) end
+
+	if parts[1] == "markdown" then
+		if parts[2] == "table" then return "markdown-table" end
+		return "markdown-list"
+	end
+
+	local format = parts[1] or "text"
+	if not validFormats[format] then
+		print("|cffFF0000[GRE]:|r Unknown format '" .. format .. "', defaulting to text.")
+		format = "text"
+	end
+
+	return format
+end
+
+-- Returns "Online" for online members, "Offline" for offline members.
+local function formatLastOnline(isOnline)
+	return isOnline and "Online" or "Offline"
+end
+
+local function captureRosterData()
+	local guildName = GetGuildInfo("player")
+	if not guildName then return false end
+
+	local totalMembers = GetNumGuildMembers()
+	local members = {}
+	for i = 1, totalMembers do
+		local name, rankName, _, level, classDisplayName, _, _, _, isOnline = GetGuildRosterInfo(i)
+		if name then
+			table.insert(members, {
+				name       = name,
+				class      = classDisplayName,
+				level      = level,
+				rank       = rankName,
+				lastOnline = formatLastOnline(isOnline),
+			})
+		end
+	end
+
+	gre.rosterData = {
+		guildName = guildName,
+		server    = GetRealmName(),
+		members   = members,
+	}
+
+	return true
+end
+
+local function buildHeader(data, memberCount, format)
+	if format == "csv" or format == "markdown-table" then
+		return ""
+	elseif format == "markdown-list" then
+		return "**Guild:** " .. data.guildName .. " — " .. data.server .. "  \n" ..
+		       "**Members:** " .. memberCount .. "  \n\n"
+	else
+		return "Guild: " .. data.guildName .. " — " .. data.server .. "  \n" ..
+		       "Members: " .. memberCount .. "  \n" ..
+		       "---------------------\n"
+	end
+end
+
+local function printHelp()
+	print("\124cff00FF00GRE:\124r \124cff00FF00S\124rimple \124cff00FF00G\124ruild \124cff00FF00R\124roster \124cff00FF00E\124rxporter - Help")
+	print("\124cff00FF00GRE:\124r Type '/grexport help' to show this message")
+	print("\124cff00FF00GRE:\124r '/grexport' - plain text list")
+	print("\124cff00FF00GRE:\124r '/grexport csv' - Comma Separated Value list")
+	print("\124cff00FF00GRE:\124r '/grexport markdown list' - Markdown list (name, level, class)")
+	print("\124cff00FF00GRE:\124r '/grexport markdown table' - Markdown table (all fields)")
+end
+
+local columns = { "Name", "Class", "Level", "Rank", "Last Online" }
+
+-- onRefresh callback passed to SWE.CreateExportWindow.
+-- Builds the full export text from gre.rosterData for the given format.
+local function buildExportText(format, _scope)
+	gre.lastFormat = format
+	if not gre.rosterData then return "", "" end
+	local data = gre.rosterData
+	local lf   = libFormat(format)
+
+	local lines = {}
+
+	if format == "csv" or format == "markdown-table" then
+		lines[#lines + 1] = SWE.RenderHeader(lf, columns)
+	end
+
+	for _, member in ipairs(data.members) do
+		if format == "markdown-list" then
+			local entry = member.name .. ", Level " .. member.level .. " " .. member.class
+			lines[#lines + 1] = SWE.RenderRow(lf, { entry })
+		else
+			lines[#lines + 1] = SWE.RenderRow(lf, {
+				member.name,
+				member.class,
+				tostring(member.level),
+				member.rank,
+				member.lastOnline,
+			})
+		end
+	end
+
+	local count  = #data.members
+	local header = buildHeader(data, count, format)
+	local title  = data.guildName .. " — " .. count .. " members"
+	return header .. table.concat(lines), title
+end
+
+local function runExport(exportType)
+	if not exportWindow then
+		exportWindow = SWE.CreateExportWindow({
+			buttons = {
+				{ label = "Text",     value = "text" },
+				{ label = "CSV",      value = "csv" },
+				{ label = "MD List",  value = "markdown-list" },
+				{ label = "MD Table", value = "markdown-table" },
+			},
+			defaultFormat = "text",
+			hasScope      = false,
+			onRefresh     = buildExportText,
+		})
+	end
+
+	gre.lastFormat = exportType
+	pendingFormat  = exportType
+	requestRoster()
+end
+
+local function attachGuildButton()
+	if gre.guildButton then return end
+	if not GuildFrame or not GuildFramePortrait then return end
+
+	local button = CreateFrame("Button", nil, GuildFrame, "UIPanelButtonTemplate")
+	button:SetSize(72, 18)
+	button:SetText("GRExport")
+	button:SetPoint("LEFT", GuildFramePortrait, "RIGHT", 9, 12)
+	button:SetScript("OnClick", function()
+		runExport(gre.lastFormat or "text")
+	end)
+
+	gre.guildButton = button
+end
+
+local eventFrame = CreateFrame("Frame")
+eventFrame:RegisterEvent("ADDON_LOADED")
+eventFrame:RegisterEvent("GUILD_ROSTER_UPDATE")
+eventFrame:SetScript("OnEvent", function(self, event, arg1)
+	if event == "ADDON_LOADED" and arg1 == addonName then
+		if not gre.SWE then
+			print("\124cffFF0000[GRE] Error:\124r SimpleWowExportersLib failed to load. Ensure SimpleWowExportersLib.lua is in the addon folder.")
+			self:UnregisterEvent("ADDON_LOADED")
+			self:UnregisterEvent("GUILD_ROSTER_UPDATE")
+			return
+		end
+		local getMetadata = (C_AddOns and C_AddOns.GetAddOnMetadata) or GetAddOnMetadata
+		local version     = getMetadata and getMetadata(addonName, "Version")
+		local versionStr  = version and " v" .. version or ""
+		print("\124cff00FF00SimpleGuildRosterExporter" .. versionStr .. "\124r loaded. Type \124cff00FF00/grexport help\124r for usage.")
+		self:UnregisterEvent("ADDON_LOADED")
+	elseif event == "GUILD_ROSTER_UPDATE" then
+		attachGuildButton()
+		if pendingFormat then
+			captureRosterData()
+			if exportWindow and gre.rosterData then
+				exportWindow:Open(pendingFormat, false)
+			end
+			pendingFormat = nil
+		end
+	end
+end)
+
+SLASH_SIMPLEGUILDROSTEREXPORTER1 = "/grexport"
+SlashCmdList["SIMPLEGUILDROSTEREXPORTER"] = function(msg)
+	if msg == "help" then
+		printHelp()
+		return
+	end
+	local exportType = parseCommand(msg)
+	runExport(exportType)
+end

--- a/SimpleGuildRosterExporter/SimpleGuildRosterExporter.lua
+++ b/SimpleGuildRosterExporter/SimpleGuildRosterExporter.lua
@@ -1,7 +1,7 @@
 -- SimpleGuildRosterExporter
 -- Author: Hamma
 -- Description: Exports guild roster data to plain text, CSV, Markdown list, or Markdown table format.
---              Supports all classic WoW flavors (Vanilla, TBC, Wrath, Cata, MoP).
+--              Supports all classic WoW flavors (Vanilla, TBC, Wrath, Cata, MoP) and Retail.
 --              Use /grexport or the GRExport button on the guild frame.
 
 local addonName, gre = ...
@@ -11,7 +11,12 @@ local exportWindow
 local pendingFormat = nil
 
 -- GuildRoster() is the classic API; C_GuildInfo.GuildRoster() is the retail-based client API (e.g. Anniversary)
-local requestRoster = (C_GuildInfo and C_GuildInfo.GuildRoster) or GuildRoster
+local requestRoster  = (C_GuildInfo and C_GuildInfo.GuildRoster) or GuildRoster
+-- GetAddOnMetadata lives under C_AddOns on retail-based clients (Anniversary, MoP)
+local getAddonMetadata = (C_AddOns and C_AddOns.GetAddOnMetadata) or GetAddOnMetadata
+-- Interface version ranges: Classic 10000-19999, TBC 20000-29999, Wrath 30000-39999,
+-- Cata 40000-49999, MoP 50000-59999, Retail 100000+
+local buildVersion = select(4, GetBuildInfo())
 
 local validFormats = { text = true, csv = true, ["markdown-list"] = true, ["markdown-table"] = true }
 
@@ -41,9 +46,38 @@ local function parseCommand(msg)
 	return format
 end
 
--- Returns "Online" for online members, "Offline" for offline members.
-local function formatLastOnline(isOnline)
-	return isOnline and "Online" or "Offline"
+-- Returns "Online" for online members, or a human-readable offline duration.
+-- Shows two levels of granularity (e.g. "2mo 5d", "3d 14h") suppressing
+-- smaller units when larger ones are present.
+local function formatLastOnline(isOnline, index)
+	if isOnline then return "Online" end
+	if GetGuildRosterLastOnline then
+		local years, months, days, hours = GetGuildRosterLastOnline(index)
+		if years  > 0 then
+			return months > 0 and years .. "y " .. months .. "mo ago" or years .. "y ago"
+		end
+		if months > 0 then
+			return days > 0 and months .. "mo " .. days .. "d ago" or months .. "mo ago"
+		end
+		if days   > 0 then
+			return hours > 0 and days .. "d " .. hours .. "h ago" or days .. "d ago"
+		end
+		if hours  > 0 then return hours .. "h ago" end
+		return "< 1h ago"
+	end
+	return "Offline"
+end
+
+-- Strips duplicate realm suffixes from names (Blizzard bug: "Player-Realm-Realm")
+local function cleanName(name)
+	local player, realm = name:match("^(.+)-(.+)$")
+	if player and realm then
+		local innerRealm = player:match("^.+-(.+)$")
+		if innerRealm == realm then
+			return player
+		end
+	end
+	return name
 end
 
 local function captureRosterData()
@@ -54,16 +88,19 @@ local function captureRosterData()
 	local members = {}
 	for i = 1, totalMembers do
 		local name, rankName, _, level, classDisplayName, _, _, _, isOnline = GetGuildRosterInfo(i)
-		if name then
+		if name and name ~= "" then
 			table.insert(members, {
-				name       = name,
-				class      = classDisplayName,
-				level      = level,
-				rank       = rankName,
-				lastOnline = formatLastOnline(isOnline),
+				name       = cleanName(name),
+				class      = classDisplayName or "Unknown",
+				level      = level or 0,
+				rank       = rankName or "",
+				lastOnline = formatLastOnline(isOnline, i),
+				isOnline   = isOnline and true or false,
 			})
 		end
 	end
+
+	table.sort(members, function(a, b) return a.name < b.name end)
 
 	gre.rosterData = {
 		guildName = guildName,
@@ -75,13 +112,15 @@ local function captureRosterData()
 end
 
 local function buildHeader(data, memberCount, format)
-	if format == "csv" or format == "markdown-table" then
+	if format == "csv" then
 		return ""
-	elseif format == "markdown-list" then
-		return "**Guild:** " .. data.guildName .. " — " .. data.server .. "  \n" ..
+	elseif format == "markdown-table" or format == "markdown-list" then
+		return "**Guild:** " .. data.guildName .. "  \n" ..
+		       "**Server:** " .. data.server .. "  \n" ..
 		       "**Members:** " .. memberCount .. "  \n\n"
 	else
-		return "Guild: " .. data.guildName .. " — " .. data.server .. "  \n" ..
+		return "Guild: " .. data.guildName .. "  \n" ..
+		       "Server: " .. data.server .. "  \n" ..
 		       "Members: " .. memberCount .. "  \n" ..
 		       "---------------------\n"
 	end
@@ -96,71 +135,156 @@ local function printHelp()
 	print("\124cff00FF00GRE:\124r '/grexport markdown table' - Markdown table (all fields)")
 end
 
-local columns = { "Name", "Class", "Level", "Rank", "Last Online" }
+local columns = { "Name", "Level", "Class", "Rank", "Last Online" }
+
+local function formatMemberRow(format, rendererFormat, member)
+	if format == "markdown-list" then
+		local entry = member.name .. ", Level " .. member.level .. " " .. member.class
+		return SWE.RenderRow(rendererFormat, { entry })
+	elseif format == "text" then
+		local entry = member.name .. " | " .. member.level .. " " .. member.class .. " | " .. member.rank .. " | " .. member.lastOnline
+		return SWE.RenderRow(rendererFormat, { entry })
+	else
+		return SWE.RenderRow(rendererFormat, {
+			member.name,
+			tostring(member.level),
+			member.class,
+			member.rank,
+			member.lastOnline,
+		})
+	end
+end
+
+local function memberCount(lines, format)
+	local hasHeaderRow = format == "csv" or format == "markdown-table"
+	return hasHeaderRow and (#lines - 1) or #lines
+end
 
 -- onRefresh callback passed to SWE.CreateExportWindow.
 -- Builds the full export text from gre.rosterData for the given format.
-local function buildExportText(format, _scope)
+local function buildExportText(format, includeOffline)
 	gre.lastFormat = format
 	if not gre.rosterData then return "", "" end
 	local data = gre.rosterData
-	local lf   = libFormat(format)
+	local rendererFormat = libFormat(format)
 
 	local lines = {}
 
 	if format == "csv" or format == "markdown-table" then
-		lines[#lines + 1] = SWE.RenderHeader(lf, columns)
+		lines[#lines + 1] = SWE.RenderHeader(rendererFormat, columns)
 	end
 
 	for _, member in ipairs(data.members) do
-		if format == "markdown-list" then
-			local entry = member.name .. ", Level " .. member.level .. " " .. member.class
-			lines[#lines + 1] = SWE.RenderRow(lf, { entry })
-		else
-			lines[#lines + 1] = SWE.RenderRow(lf, {
-				member.name,
-				member.class,
-				tostring(member.level),
-				member.rank,
-				member.lastOnline,
-			})
+		if includeOffline or member.isOnline then
+			lines[#lines + 1] = formatMemberRow(format, rendererFormat, member)
 		end
 	end
 
-	local count  = #data.members
+	local count  = memberCount(lines, format)
 	local header = buildHeader(data, count, format)
 	local title  = data.guildName .. " — " .. count .. " members"
 	return header .. table.concat(lines), title
 end
 
 local function runExport(exportType)
+	if not GetGuildInfo("player") then
+		print("\124cffFF0000Error:\124r You are not in a guild.")
+		return
+	end
+
 	if not exportWindow then
 		exportWindow = SWE.CreateExportWindow({
 			buttons = {
-				{ label = "Text",     value = "text" },
-				{ label = "CSV",      value = "csv" },
-				{ label = "MD List",  value = "markdown-list" },
-				{ label = "MD Table", value = "markdown-table" },
+				{ label = "Text",           value = "text",           width = 60  },
+				{ label = "CSV",            value = "csv",            width = 60  },
+				{ label = "Markdown List",  value = "markdown-list",  width = 115 },
+				{ label = "Markdown Table", value = "markdown-table", width = 115 },
 			},
 			defaultFormat = "text",
-			hasScope      = false,
+			hasScope      = true,
+			scopeLabel    = "Include offline",
 			onRefresh     = buildExportText,
 		})
 	end
 
 	gre.lastFormat = exportType
-	pendingFormat  = exportType
-	requestRoster()
+
+	-- Try to capture immediately in case data is already cached.
+	-- If data unavailable, fall back to async request.
+	if captureRosterData() then
+		exportWindow:Open(exportType, true)
+	elseif requestRoster then
+		pendingFormat = exportType
+		requestRoster()
+	else
+		print("\124cffFF0000Error:\124r Unable to request guild roster on this client.")
+	end
 end
 
 local function attachGuildButton()
 	if gre.guildButton then return end
-	if not GuildFrame or not GuildFramePortrait then return end
 
-	local button = CreateFrame("Button", nil, GuildFrame, "UIPanelButtonTemplate")
-	button:SetSize(72, 18)
-	button:SetText("GRExport")
-	button:SetPoint("LEFT", GuildFramePortrait, "RIGHT", 9, 12)
+	local frame, applyButtonPosition
+	local isMopOrRetail = (buildVersion >= 50000 and buildVersion < 60000) or buildVersion >= 100000
+	if isMopOrRetail and CommunitiesFrame and CommunitiesFrame.GuildInfoTab then
+		-- MoP Classic (50xxx) and Retail (100xxx+): icon tab on right side below GRM's tab or Blizzard's GuildInfoTab
+		frame = CommunitiesFrame
+		applyButtonPosition = function(btn)
+			btn:SetPoint("TOP", CommunitiesFrame.GuildInfoTab, "BOTTOM", 0, -64)
+		end
+	elseif CommunitiesFrame and CommunitiesFrame.portrait and CommunitiesFrame:IsShown() then
+		-- Fallback: CommunitiesFrame with portrait but no GuildInfoTab (future-proofing)
+		frame = CommunitiesFrame
+		applyButtonPosition = function(btn) btn:SetPoint("LEFT", CommunitiesFrame.portrait, "RIGHT", 9, 12) end
+	elseif GuildFrame and GuildFrame:IsShown() then
+		if GuildFramePortrait then
+			-- Wrath/Cata/Vanilla: classic guild frame with portrait
+			frame = GuildFrame
+			applyButtonPosition = function(btn) btn:SetPoint("LEFT", GuildFramePortrait, "RIGHT", 9, 12) end
+		else
+			-- TBC-style guild frame: no portrait, position next to "Show Offline Members"
+			frame = GuildFrame
+			applyButtonPosition = function(btn) btn:SetPoint("TOPLEFT", GuildFrame, "TOPLEFT", 50, -27) end
+		end
+	else
+		-- Frame not shown yet — hook for when it opens
+		local function hookOnShow(targetFrame, flagKey)
+			if targetFrame and not gre[flagKey] then
+				gre[flagKey] = true
+				targetFrame:HookScript("OnShow", attachGuildButton)
+			end
+		end
+		hookOnShow(CommunitiesFrame, "communityHooked")
+		hookOnShow(GuildFrame, "guildFrameHooked")
+		return
+	end
+
+	local isCommunitiesTabLayout = isMopOrRetail and CommunitiesFrame and CommunitiesFrame.GuildInfoTab
+
+	local button = CreateFrame("Button", nil, frame, isCommunitiesTabLayout and "UIPanelButtonGrayTemplate" or "UIPanelButtonTemplate")
+	if isCommunitiesTabLayout then
+		button:SetSize(44, 44)
+		local icon = button:CreateTexture(nil, "OVERLAY")
+		-- MoP Classic is 50xxx; Retail is 100xxx+ — adjusts icon size and centering offset to match each client's tab style
+		local isMopClassic = buildVersion < 100000
+		local iconSize  = isMopClassic and 36 or 33
+		local offsetX   = isMopClassic and 0 or 2.5
+		local offsetY   = isMopClassic and 0 or -1.5
+		icon:SetPoint("CENTER", button, "CENTER", offsetX, offsetY)
+		icon:SetSize(iconSize, iconSize)
+		icon:SetTexture("Interface\\Icons\\inv_misc_note_05")
+		button:SetScript("OnEnter", function(self)
+			GameTooltip:SetOwner(self, "ANCHOR_CURSOR")
+			GameTooltip:AddLine("SimpleGuildRosterExporter")
+			GameTooltip:AddLine("/grexport to export", 1, 1, 1)
+			GameTooltip:Show()
+		end)
+		button:SetScript("OnLeave", function() GameTooltip:Hide() end)
+	else
+		button:SetSize(72, 18)
+		button:SetText("GRExport")
+	end
+	applyButtonPosition(button)
 	button:SetScript("OnClick", function()
 		runExport(gre.lastFormat or "text")
 	end)
@@ -171,6 +295,7 @@ end
 local eventFrame = CreateFrame("Frame")
 eventFrame:RegisterEvent("ADDON_LOADED")
 eventFrame:RegisterEvent("GUILD_ROSTER_UPDATE")
+eventFrame:RegisterEvent("PLAYER_GUILD_UPDATE")
 eventFrame:SetScript("OnEvent", function(self, event, arg1)
 	if event == "ADDON_LOADED" and arg1 == addonName then
 		if not gre.SWE then
@@ -179,17 +304,17 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1)
 			self:UnregisterEvent("GUILD_ROSTER_UPDATE")
 			return
 		end
-		local getMetadata = (C_AddOns and C_AddOns.GetAddOnMetadata) or GetAddOnMetadata
-		local version     = getMetadata and getMetadata(addonName, "Version")
-		local versionStr  = version and " v" .. version or ""
-		print("\124cff00FF00SimpleGuildRosterExporter" .. versionStr .. "\124r loaded. Type \124cff00FF00/grexport help\124r for usage.")
+		local version = getAddonMetadata and getAddonMetadata(addonName, "Version")
+		SWE.RegisterAddon("SimpleGuildRosterExporter", version, "/grexport help")
 		self:UnregisterEvent("ADDON_LOADED")
-	elseif event == "GUILD_ROSTER_UPDATE" then
+	elseif event == "GUILD_ROSTER_UPDATE" or event == "PLAYER_GUILD_UPDATE" then
 		attachGuildButton()
 		if pendingFormat then
-			captureRosterData()
-			if exportWindow and gre.rosterData then
-				exportWindow:Open(pendingFormat, false)
+			local captured = captureRosterData()
+			if captured and exportWindow and gre.rosterData then
+				exportWindow:Open(pendingFormat, true)
+			elseif not captured then
+				print("\124cffFF0000Error:\124r Unable to capture guild roster data.")
 			end
 			pendingFormat = nil
 		end

--- a/SimpleGuildRosterExporter/SimpleGuildRosterExporter.toc
+++ b/SimpleGuildRosterExporter/SimpleGuildRosterExporter.toc
@@ -1,0 +1,15 @@
+## Interface: 50503
+## Interface-Mists: 50503
+## Interface-TBC: 20505
+## Interface-Vanilla: 11508
+## Interface-Wrath: 30405
+## Interface-Cata: 40402
+## Title: SimpleGuildRosterExporter |cFF00FF00@project-version@|r
+## Author: Hamma
+## Notes: A simple guild roster exporter
+## Version: @project-version@
+## IconTexture: Interface\Icons\Achievement_GuildPerk_HaveGroupWillTravel
+## Category: Simple WoW Exporters
+
+Shared/SimpleWowExportersLib.lua
+SimpleGuildRosterExporter.lua

--- a/SimpleGuildRosterExporter/SimpleGuildRosterExporter.toc
+++ b/SimpleGuildRosterExporter/SimpleGuildRosterExporter.toc
@@ -9,7 +9,7 @@
 ## Notes: A simple guild roster exporter
 ## Version: @project-version@
 ## X-Curse-Project-ID: 1523985
-## X-Wago-ID: 
+## X-Wago-ID: QN53poKB
 ## IconTexture: Interface\Icons\INV_Letter_15
 ## Category: Simple WoW Exporters
 

--- a/SimpleGuildRosterExporter/SimpleGuildRosterExporter.toc
+++ b/SimpleGuildRosterExporter/SimpleGuildRosterExporter.toc
@@ -8,7 +8,9 @@
 ## Author: Hamma
 ## Notes: A simple guild roster exporter
 ## Version: @project-version@
-## IconTexture: Interface\Icons\Achievement_GuildPerk_HaveGroupWillTravel
+## X-Curse-Project-ID: 1523985
+## X-Wago-ID: 
+## IconTexture: Interface\Icons\INV_Letter_15
 ## Category: Simple WoW Exporters
 
 Shared/SimpleWowExportersLib.lua

--- a/SimpleGuildRosterExporter/SimpleGuildRosterExporter.toc
+++ b/SimpleGuildRosterExporter/SimpleGuildRosterExporter.toc
@@ -1,5 +1,6 @@
 ## Interface: 50503
 ## Interface-Mists: 50503
+## Interface-Retail: 120005
 ## Interface-TBC: 20505
 ## Interface-Vanilla: 11508
 ## Interface-Wrath: 30405

--- a/SimpleTradeSkillExporter-CHANGELOG.md
+++ b/SimpleTradeSkillExporter-CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.3.2
+Adds combined suite load message and /swexport help command shared across all Simple WoW Exporters addons.
+
+- Load message now shows all installed Simple WoW Exporters addons on a single line
+- Added /swexport help to list available commands across all loaded addons
+
 # 1.3.1
 Fixes load message across all classic flavors and defaults export scope to all expansions.
 

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
@@ -232,7 +232,7 @@ local eventFrame = CreateFrame("Frame")
 eventFrame:RegisterEvent("ADDON_LOADED")
 eventFrame:RegisterEvent("TRADE_SKILL_SHOW")
 eventFrame:SetScript("OnEvent", function(self, event, arg1)
-if event == "ADDON_LOADED" and arg1 == addonName then
+	if event == "ADDON_LOADED" and arg1 == addonName then
 		if not tse.SWE then
 			print(
 			"\124cffFF0000[TSE] Error:\124r SimpleWowExportersLib failed to load. Ensure SimpleWowExportersLib.lua is in the addon folder.")

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
@@ -5,7 +5,7 @@
 --              Use /tsexport or the Export button on the tradeskill window.
 
 local addonName, tse = ...
-local SWE = tse.SWE  -- loaded by SimpleWowExportersLib.lua via TOC
+local SWE = tse.SWE -- loaded by SimpleWowExportersLib.lua via TOC
 
 local wowheadUrls = {
 	[WOW_PROJECT_MISTS_CLASSIC]           = "https://wowhead.com/mop-classic/",
@@ -75,9 +75,10 @@ end
 local function buildHeader(player, skillName, rank, recipeCount, exportType)
 	if exportType == "markdown" then
 		local h =
-			"**Player:** " .. player.name .. ", Level " .. player.level .. " " .. player.race .. " " .. player.class .. "  \n" ..
-			"**Guild:** "   .. player.guild  .. "  \n" ..
-			"**Server:** "  .. player.server .. "  \n"
+			"**Player:** " ..
+			player.name .. ", Level " .. player.level .. " " .. player.race .. " " .. player.class .. "  \n" ..
+			"**Guild:** " .. player.guild .. "  \n" ..
+			"**Server:** " .. player.server .. "  \n"
 		if rank > 0 then
 			h = h .. "**" .. skillName .. ":** Skill " .. rank .. ", " .. recipeCount .. " total recipes  \n"
 		end
@@ -86,9 +87,10 @@ local function buildHeader(player, skillName, rank, recipeCount, exportType)
 		return ""
 	else
 		local h =
-			"Player: " .. player.name .. ", Level " .. player.level .. " " .. player.race .. " " .. player.class .. "  \n" ..
-			"Guild: "   .. player.guild  .. "  \n" ..
-			"Server: "  .. player.server .. "  \n"
+			"Player: " ..
+			player.name .. ", Level " .. player.level .. " " .. player.race .. " " .. player.class .. "  \n" ..
+			"Guild: " .. player.guild .. "  \n" ..
+			"Server: " .. player.server .. "  \n"
 		if rank > 0 then
 			h = h .. skillName .. " skill " .. rank .. ", " .. recipeCount .. " total recipes  \n"
 		end
@@ -97,7 +99,8 @@ local function buildHeader(player, skillName, rank, recipeCount, exportType)
 end
 
 local function printHelp()
-	print("\124cff00FF00TSE:\124r \124cff00FF00S\124rimple \124cff00FF00T\124rradeskill \124cff00FF00E\124rxporter - Help")
+	print(
+	"\124cff00FF00TSE:\124r \124cff00FF00S\124rimple \124cff00FF00T\124rradeskill \124cff00FF00E\124rxporter - Help")
 	print("\124cff00FF00TSE:\124r Type '/tsexport help' to show this message")
 	print("\124cff00FF00TSE:\124r Open a tradeskill window, then type one of the following commands")
 	print("\124cff00FF00TSE:\124r By default, all expansions are exported")
@@ -195,10 +198,10 @@ local function runExport(exportType, exportAll)
 
 	if not exportWindow then
 		exportWindow = SWE.CreateExportWindow({
-			buttons = {
+			buttons       = {
 				{ label = "Text",     value = "text" },
 				{ label = "CSV",      value = "csv",      disabled = not tse.wowheadBase },
-				{ label = "Markdown", value = "markdown",  disabled = not tse.wowheadBase },
+				{ label = "Markdown", value = "markdown", disabled = not tse.wowheadBase },
 			},
 			defaultFormat = "text",
 			hasScope      = tse.expansionItemIdFloor ~= nil,
@@ -229,17 +232,17 @@ local eventFrame = CreateFrame("Frame")
 eventFrame:RegisterEvent("ADDON_LOADED")
 eventFrame:RegisterEvent("TRADE_SKILL_SHOW")
 eventFrame:SetScript("OnEvent", function(self, event, arg1)
-	if event == "ADDON_LOADED" and arg1 == addonName then
+if event == "ADDON_LOADED" and arg1 == addonName then
 		if not tse.SWE then
-			print("\124cffFF0000[TSE] Error:\124r SimpleWowExportersLib failed to load. Ensure SimpleWowExportersLib.lua is in the addon folder.")
+			print(
+			"\124cffFF0000[TSE] Error:\124r SimpleWowExportersLib failed to load. Ensure SimpleWowExportersLib.lua is in the addon folder.")
 			self:UnregisterEvent("ADDON_LOADED")
 			self:UnregisterEvent("TRADE_SKILL_SHOW")
 			return
 		end
 		local getMetadata = (C_AddOns and C_AddOns.GetAddOnMetadata) or GetAddOnMetadata
 		local version = getMetadata and getMetadata(addonName, "Version")
-		local versionStr = version and " v" .. version or ""
-		print("\124cff00FF00SimpleTradeSkillExporter" .. versionStr .. "\124r loaded. Type \124cff00FF00/tsexport help\124r for usage.")
+		SWE.RegisterAddon("SimpleTradeSkillExporter", version, "/tsexport help")
 		self:UnregisterEvent("ADDON_LOADED")
 	elseif event == "TRADE_SKILL_SHOW" then
 		attachTradeSkillButton()


### PR DESCRIPTION
## Summary

Introduces **SimpleGuildRosterExporter** as the second addon in the Simple WoW Exporters suite, with full support for all classic WoW flavors and Retail.

- **Export formats:** Plain text, CSV, Markdown list, and Markdown table — switchable without closing the window
- **Offline members:** Toggle via "Include offline" checkbox; last-online shown as human-readable duration (e.g. "5d 2h ago")
- **Multi-client button:** GRExport title bar button on Classic Era, TBC, Wrath, and Cata; icon tab on the CommunitiesFrame right panel for MoP Classic and Retail
- **Shared load message:** Both addons now report on a single combined line at login; `/swexport help` lists commands across all loaded exporters
- **Release pipeline:** `guild-v*` tags now trigger a dedicated GRE release job; `trade-v*` continues to release TSE independently

### Shared library enhancements (`SimpleWowExportersLib.lua`)
- Added `SWE.RegisterAddon` for cross-addon coordination via `_G.SWERegistry`
- Export window now resizable (guarded for Vanilla 1.x clients that lack the API)
- `CreateExportWindow` config extended: `scopeLabel` (customise checkbox text), per-button `width`

### SimpleTradeSkillExporter (`v1.3.2`)
- Adopted `SWE.RegisterAddon` for the combined load message and `/swexport help`
