### PR TITLE
TSE: Retail (The War Within) Support & Markdown Table Format

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -26068,7 +26068,8 @@ read_globals = {
      },
      C_TradeSkillUI = {
          fields = {
-             'GetChildProfessionInfo',
+              'GetBaseProfessionInfo',
+              'GetChildProfessionInfo',
              'GetFilteredRecipeIDs',
              'GetProfessionInfoByRecipeID',
              'GetRecipeInfo',

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -17091,8 +17091,9 @@ read_globals = {
     'ProductChoiceItem_OnClick',
     'PromoteToAssistant',
     'PromoteToLeader',
-    'PropagateForbiddenToReferencedFrames',
-    'PropertyBindingMixin',
+     'PropagateForbiddenToReferencedFrames',
+     'ProfessionsFrame',
+     'PropertyBindingMixin',
     'PropertyButtonMixin',
     'PropertyFontStringMixin',
     'PropertySliderMixin',
@@ -24477,8 +24478,9 @@ read_globals = {
     'WOW_PROJECT_BURNING_CRUSADE_CLASSIC',
     'WOW_PROJECT_CATACLYSM_CLASSIC',
     'WOW_PROJECT_CLASSIC',
-    'WOW_PROJECT_ID',
-    'WOW_PROJECT_MISTS_CLASSIC',
+     'WOW_PROJECT_ID',
+     'WOW_PROJECT_MAINLINE',
+     'WOW_PROJECT_MISTS_CLASSIC',
     'WOW_PROJECT_WRATH_CLASSIC',
     'WRISTSLOT',
     'WRONG_SLOT_FOR_ITEM',
@@ -26058,12 +26060,23 @@ read_globals = {
             'NewTimer'
         }
     },
-    C_ToyBoxInfo = {
-        fields = {
-            'ClearFanfare',
-            'NeedsFanfare'
-        }
-    },
+     C_ToyBoxInfo = {
+         fields = {
+             'ClearFanfare',
+             'NeedsFanfare'
+         }
+     },
+     C_TradeSkillUI = {
+         fields = {
+             'GetChildProfessionInfo',
+             'GetFilteredRecipeIDs',
+             'GetProfessionInfoByRecipeID',
+             'GetRecipeInfo',
+             'GetRecipeItemLink',
+             'GetRecipeLink',
+             'IsRecipeInSkillLine',
+         }
+     },
     C_Traits = {
         fields = {
             'CanPurchaseRank',

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Overview
 
-Simple World of Warcraft exporters is a suite of focused addons that make it easy to export your in game data. These tools empower players and guilds to organize their trade skills, rosters and more. Every addon offers multiple export options including Text, CSV and Markdown formatted.
+Simple World of Warcraft exporters is a suite of focused addons that make it easy to export your in game data. These tools empower players and guilds to organize their trade skills, rosters and more. Supports Retail and all classic WoW flavors. Every addon offers multiple export options including Text, CSV and Markdown formats.
 
 ## SimpleTradeSkillExporter
 
-Simple Trade Skill Exporter is an addon which allows you to export your learned trade skill recipes. It supports all professions and triggered via the tradeskill window or slash commands. You can export your recipes as plain text, Markdown With Wowhead links, or CSV with Wowhead links. Originally inspired by TradeSkillExporter, created with permission from GrumpyOldLisian. Part of the *SimpleWowExporters* collection of addons.
+Simple Trade Skill Exporter is an addon which allows you to export your learned trade skill recipes. It supports all professions and is triggered via the tradeskill window or slash commands. You can export your recipes as plain text, Markdown list, Markdown table, or CSV — with Wowhead links on supported clients. Supports Retail (The War Within) and all classic WoW flavors. Originally inspired by TradeSkillExporter, created with permission from GrumpyOldLisian. Part of the *SimpleWowExporters* collection of addons.
 
 ### Supported Versions
 
+- Retail (The War Within)
 - Mists of Pandaria Classic
 - Cataclysm Classic
 - Wrath of the Lich King Classic
@@ -18,7 +19,7 @@ Simple Trade Skill Exporter is an addon which allows you to export your learned 
 
 Open any trade skill window, then either click the **TSExport** button in the title bar or use `/tsexport`.
 
-The export window opens with format (Text, CSV, Markdown) and scope controls built in — all expansions are shown by default. Uncheck "All expansions" to limit to the current expansion only.
+The export window opens with format (Text, CSV, MD List, MD Table) and scope controls built in. Check "All expansions" to include all expansions, or leave unchecked to limit to the current expansion only.
 
 Use the **Select All** button or CTRL-A, then CTRL-C to copy the output and paste it wherever you need it.
 
@@ -28,8 +29,10 @@ Use the **Select All** button or CTRL-A, then CTRL-C to copy the output and past
 |---------|--------|
 | `/tsexport` | Plain text — all expansions |
 | `/tsexport current` | Plain text — current expansion only |
-| `/tsexport markdown` | Markdown with Wowhead links — all expansions |
-| `/tsexport markdown current` | Markdown with Wowhead links — current expansion only |
+| `/tsexport markdown` | Markdown list with Wowhead links — all expansions |
+| `/tsexport markdown current` | Markdown list with Wowhead links — current expansion only |
+| `/tsexport markdown table` | Markdown table with Wowhead links — all expansions |
+| `/tsexport markdown table current` | Markdown table with Wowhead links — current expansion only |
 | `/tsexport csv` | CSV with Wowhead hyperlinks — all expansions |
 | `/tsexport csv current` | CSV with Wowhead hyperlinks — current expansion only |
 | `/tsexport help` | Show available commands |
@@ -42,7 +45,7 @@ Simple Guild Roster Exporter allows you to export your guild roster to plain tex
 
 ### Supported Versions
 
-- Retail (The War Within / Midnight)
+- Retail (The War Within)
 - Mists of Pandaria Classic
 - Cataclysm Classic
 - Wrath of the Lich King Classic

--- a/Shared/SimpleWowExportersLib.lua
+++ b/Shared/SimpleWowExportersLib.lua
@@ -43,6 +43,9 @@ ns.SWE = {}
 local SWE = ns.SWE
 
 -- Shared registry across all addon instances — uses a global so both lib copies can coordinate.
+-- addons: list of registered addon descriptors ({ name, version, helpCommand })
+-- slashRegistered: ensures /swexport is only registered once across both lib copies
+-- loadTimer: debounce handle so the load message prints after all addons have registered
 _G.SWERegistry = _G.SWERegistry or { addons = {}, slashRegistered = false, loadTimer = nil }
 
 -- SWE.RegisterAddon(name, version, helpCommand)
@@ -67,7 +70,8 @@ function SWE.RegisterAddon(name, version, helpCommand)
 	_G.SWERegistry.loadTimer = C_Timer.NewTimer(0.5, function()
 		local names = {}
 		for _, addon in ipairs(_G.SWERegistry.addons) do
-			local ver = addon.version and addon.version:match("v%d+%.%d+%.%d+")
+			-- Match only clean semver tags like "v1.2.3"; dev/alpha builds may not match and are omitted
+		local ver = addon.version and addon.version:match("v%d+%.%d+%.%d+")
 			table.insert(names, addon.name .. (ver and " \124cff00FF00" .. ver .. "\124r" or ""))
 		end
 		print("\124cff00FF00SimpleWowExporters\124r loaded: " .. table.concat(names, ", ") .. ". Type \124cff00FF00/swexport help\124r for commands.")
@@ -284,7 +288,7 @@ function SWE.CreateExportWindow(config)
 	closeBtn:SetScript("OnClick", function() frame:Hide() end)
 
 	-- Syncs button pushed state and text colour to selectedFormat.
-	-- Selected: white (1,1,1). Unselected: WoW gold (1,0.82,0).
+	-- Selected: white (1,1,1). Unselected: WoW UI gold RGB (1, 0.82, 0).
 	frame.updateControls = function()
 		for _, btn in ipairs(frame.formatButtons) do
 			local selected = btn.value == selectedFormat
@@ -307,9 +311,10 @@ function SWE.CreateExportWindow(config)
 	frame:SetScript("OnShow", function() frame.updateControls() end)
 
 	-- Public: set format + scope, then show.
-	function frame:Open(format, scope)
+	frame.Open = function(self, format, scope)
 		selectedFormat = format or selectedFormat
-		selectedScope  = scope  or false
+		-- Preserve current selectedScope if scope is not explicitly passed
+		selectedScope  = scope ~= nil and scope or selectedScope
 		frame.updateControls()
 		frame.refresh()
 		frame:Show()

--- a/SimpleGuildRosterExporter-CHANGELOG.md
+++ b/SimpleGuildRosterExporter-CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.0.1
+Fixes plain text header formatting and export window scope preservation.
+
+- Fixed plain text export header using markdown-style line breaks — now uses standard line endings
+- Fixed export window losing the selected scope when switching formats
+- Fixed export not triggering when guild roster data was unavailable at the time of the request on some clients
+
 # 1.0.0
 Initial release of SimpleGuildRosterExporter.
 

--- a/SimpleGuildRosterExporter/SimpleGuildRosterExporter.lua
+++ b/SimpleGuildRosterExporter/SimpleGuildRosterExporter.lua
@@ -117,12 +117,12 @@ local function buildHeader(data, memberCount, format)
 	elseif format == "markdown-table" or format == "markdown-list" then
 		return "**Guild:** " .. data.guildName .. "  \n" ..
 		       "**Server:** " .. data.server .. "  \n" ..
-		       "**Members:** " .. memberCount .. "  \n\n"
+		       "**Members:** " .. memberCount .. "  \n" ..
+		       (format == "markdown-table" and "\n" or "")
 	else
 		return "Guild: " .. data.guildName .. "  \n" ..
 		       "Server: " .. data.server .. "  \n" ..
-		       "Members: " .. memberCount .. "  \n" ..
-		       "---------------------\n"
+		       "Members: " .. memberCount .. "  \n"
 	end
 end
 

--- a/SimpleGuildRosterExporter/SimpleGuildRosterExporter.lua
+++ b/SimpleGuildRosterExporter/SimpleGuildRosterExporter.lua
@@ -8,15 +8,14 @@ local addonName, gre = ...
 local SWE = gre.SWE  -- loaded by SimpleWowExportersLib.lua via TOC
 
 local exportWindow
+-- Holds the requested export format across an async GuildRoster() request.
+-- Set in runExport when roster data is unavailable; cleared after GUILD_ROSTER_UPDATE fires.
 local pendingFormat = nil
 
 -- GuildRoster() is the classic API; C_GuildInfo.GuildRoster() is the retail-based client API (e.g. Anniversary)
 local requestRoster  = (C_GuildInfo and C_GuildInfo.GuildRoster) or GuildRoster
 -- GetAddOnMetadata lives under C_AddOns on retail-based clients (Anniversary, MoP)
 local getAddonMetadata = (C_AddOns and C_AddOns.GetAddOnMetadata) or GetAddOnMetadata
--- Interface version ranges: Classic 10000-19999, TBC 20000-29999, Wrath 30000-39999,
--- Cata 40000-49999, MoP 50000-59999, Retail 100000+
-local buildVersion = select(4, GetBuildInfo())
 
 local validFormats = { text = true, csv = true, ["markdown-list"] = true, ["markdown-table"] = true }
 
@@ -85,8 +84,10 @@ local function captureRosterData()
 	if not guildName then return false end
 
 	local totalMembers = GetNumGuildMembers()
+	if totalMembers == 0 then return false end
 	local members = {}
 	for i = 1, totalMembers do
+		-- GetGuildRosterInfo returns: name, rankName, rankIndex, level, class, zone, note, officerNote, isOnline, ...
 		local name, rankName, _, level, classDisplayName, _, _, _, isOnline = GetGuildRosterInfo(i)
 		if name and name ~= "" then
 			table.insert(members, {
@@ -117,12 +118,11 @@ local function buildHeader(data, memberCount, format)
 	elseif format == "markdown-table" or format == "markdown-list" then
 		return "**Guild:** " .. data.guildName .. "  \n" ..
 		       "**Server:** " .. data.server .. "  \n" ..
-		       "**Members:** " .. memberCount .. "  \n" ..
-		       (format == "markdown-table" and "\n" or "")
+		       "**Members:** " .. memberCount .. "  \n\n"
 	else
-		return "Guild: " .. data.guildName .. "  \n" ..
-		       "Server: " .. data.server .. "  \n" ..
-		       "Members: " .. memberCount .. "  \n"
+		return "Guild: " .. data.guildName .. "\n" ..
+		       "Server: " .. data.server .. "\n" ..
+		       "Members: " .. memberCount .. "\n\n"
 	end
 end
 
@@ -137,15 +137,15 @@ end
 
 local columns = { "Name", "Level", "Class", "Rank", "Last Online" }
 
-local function formatMemberRow(format, rendererFormat, member)
+local function formatMemberRow(format, libRendererFormat, member)
 	if format == "markdown-list" then
 		local entry = member.name .. ", Level " .. member.level .. " " .. member.class
-		return SWE.RenderRow(rendererFormat, { entry })
+		return SWE.RenderRow(libRendererFormat, { entry })
 	elseif format == "text" then
 		local entry = member.name .. " | " .. member.level .. " " .. member.class .. " | " .. member.rank .. " | " .. member.lastOnline
-		return SWE.RenderRow(rendererFormat, { entry })
+		return SWE.RenderRow(libRendererFormat, { entry })
 	else
-		return SWE.RenderRow(rendererFormat, {
+		return SWE.RenderRow(libRendererFormat, {
 			member.name,
 			tostring(member.level),
 			member.class,
@@ -155,7 +155,8 @@ local function formatMemberRow(format, rendererFormat, member)
 	end
 end
 
-local function memberCount(lines, format)
+local function computeMemberCount(lines, format)
+	-- csv and markdown-table prepend a header row that must not be counted as a member
 	local hasHeaderRow = format == "csv" or format == "markdown-table"
 	return hasHeaderRow and (#lines - 1) or #lines
 end
@@ -166,21 +167,21 @@ local function buildExportText(format, includeOffline)
 	gre.lastFormat = format
 	if not gre.rosterData then return "", "" end
 	local data = gre.rosterData
-	local rendererFormat = libFormat(format)
+	local libRendererFormat = libFormat(format)
 
 	local lines = {}
 
 	if format == "csv" or format == "markdown-table" then
-		lines[#lines + 1] = SWE.RenderHeader(rendererFormat, columns)
+		lines[#lines + 1] = SWE.RenderHeader(libRendererFormat, columns)
 	end
 
 	for _, member in ipairs(data.members) do
 		if includeOffline or member.isOnline then
-			lines[#lines + 1] = formatMemberRow(format, rendererFormat, member)
+			lines[#lines + 1] = formatMemberRow(format, libRendererFormat, member)
 		end
 	end
 
-	local count  = memberCount(lines, format)
+	local count  = computeMemberCount(lines, format)
 	local header = buildHeader(data, count, format)
 	local title  = data.guildName .. " — " .. count .. " members"
 	return header .. table.concat(lines), title
@@ -221,11 +222,26 @@ local function runExport(exportType)
 	end
 end
 
-local function attachGuildButton()
-	if gre.guildButton then return end
+-- Forward declaration required because hookFrameOnShow references attachGuildButton
+-- before it is defined below.
+local attachGuildButton
 
-	local frame, applyButtonPosition
+-- Hooks attachGuildButton onto targetFrame's OnShow if not already hooked.
+-- flagKey is a gre table key used to track whether the hook has been applied.
+local function hookFrameOnShow(targetFrame, flagKey)
+	if targetFrame and not gre[flagKey] then
+		gre[flagKey] = true
+		targetFrame:HookScript("OnShow", attachGuildButton)
+	end
+end
+
+attachGuildButton = function()
+	if gre.guildButton then return end
+	-- GetBuildInfo() field 4 is the numeric interface version (e.g. 50400 for MoP 5.4, 120005 for Retail)
+	-- MoP Classic: 50000–59999. Retail: 100000+. All others are earlier classic flavors.
+	local buildVersion = select(4, GetBuildInfo())
 	local isMopOrRetail = (buildVersion >= 50000 and buildVersion < 60000) or buildVersion >= 100000
+	local frame, applyButtonPosition
 	if isMopOrRetail and CommunitiesFrame and CommunitiesFrame.GuildInfoTab then
 		-- MoP Classic (50xxx) and Retail (100xxx+): icon tab on right side below GRM's tab or Blizzard's GuildInfoTab
 		frame = CommunitiesFrame
@@ -248,14 +264,8 @@ local function attachGuildButton()
 		end
 	else
 		-- Frame not shown yet — hook for when it opens
-		local function hookOnShow(targetFrame, flagKey)
-			if targetFrame and not gre[flagKey] then
-				gre[flagKey] = true
-				targetFrame:HookScript("OnShow", attachGuildButton)
-			end
-		end
-		hookOnShow(CommunitiesFrame, "communityHooked")
-		hookOnShow(GuildFrame, "guildFrameHooked")
+		hookFrameOnShow(CommunitiesFrame, "communityHooked")
+		hookFrameOnShow(GuildFrame, "guildFrameHooked")
 		return
 	end
 
@@ -308,7 +318,7 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1)
 		self:UnregisterEvent("ADDON_LOADED")
 	elseif event == "GUILD_ROSTER_UPDATE" or event == "PLAYER_GUILD_UPDATE" then
 		attachGuildButton()
-		if pendingFormat then
+		if event == "GUILD_ROSTER_UPDATE" and pendingFormat then
 			local captured = captureRosterData()
 			if captured and exportWindow and gre.rosterData then
 				exportWindow:Open(pendingFormat, true)

--- a/SimpleTradeSkillExporter-CHANGELOG.md
+++ b/SimpleTradeSkillExporter-CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.4.0
+Adds Retail (The War Within) support and a new Markdown Table export format.
+
+- Added full support for Retail WoW (The War Within) — export recipes from all professions
+- Retail exports group recipes by expansion with section headers (text/markdown) or an Expansion column (CSV/MD Table)
+- Added Markdown Table export format — available via the **MD Table** button or `/tsexport markdown table`
+- Export window format buttons now labelled **Text**, **CSV**, **MD List**, **MD Table**
+- **All expansions** scope toggle now available on Retail
+
 # 1.3.2
 Adds combined suite load message and /swexport help command shared across all Simple WoW Exporters addons.
 

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
@@ -7,21 +7,35 @@
 local addonName, tse = ...
 local SWE = tse.SWE -- loaded by SimpleWowExportersLib.lua via TOC
 
+-- WOW_PROJECT_* constants are only defined on their respective clients.
+-- Use numeric literals as table keys to avoid nil key errors on other clients.
+-- Values sourced from https://warcraft.wiki.gg/wiki/WOW_PROJECT_ID
+local PROJECT_MAINLINE   = 1
+local PROJECT_CLASSIC    = 2
+local PROJECT_TBC        = 5
+local PROJECT_WRATH      = 11
+local PROJECT_CATA       = 14
+local PROJECT_MISTS      = 19
+
+local isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
+
 local wowheadUrls = {
-	[WOW_PROJECT_MISTS_CLASSIC]           = "https://wowhead.com/mop-classic/",
-	[WOW_PROJECT_CATACLYSM_CLASSIC]       = "https://wowhead.com/cata/",
-	[WOW_PROJECT_WRATH_CLASSIC]           = "https://wowhead.com/wotlk/",
-	[WOW_PROJECT_BURNING_CRUSADE_CLASSIC] = "https://wowhead.com/tbc/",
-	[WOW_PROJECT_CLASSIC]                 = "https://wowhead.com/classic/",
+	[PROJECT_MAINLINE] = "https://www.wowhead.com/",
+	[PROJECT_MISTS]    = "https://wowhead.com/mop-classic/",
+	[PROJECT_CATA]     = "https://wowhead.com/cata/",
+	[PROJECT_WRATH]    = "https://wowhead.com/wotlk/",
+	[PROJECT_TBC]      = "https://wowhead.com/tbc/",
+	[PROJECT_CLASSIC]  = "https://wowhead.com/classic/",
 }
 tse.wowheadBase = wowheadUrls[WOW_PROJECT_ID]
 
 local expansionItemIdFloors = {
-	[WOW_PROJECT_MISTS_CLASSIC]           = 71000,
-	[WOW_PROJECT_CATACLYSM_CLASSIC]       = 52000,
-	[WOW_PROJECT_WRATH_CLASSIC]           = 35000,
-	[WOW_PROJECT_BURNING_CRUSADE_CLASSIC] = 24000,
-	[WOW_PROJECT_CLASSIC]                 = nil,
+	[PROJECT_MAINLINE] = 210000, -- The War Within
+	[PROJECT_MISTS]    = 71000,
+	[PROJECT_CATA]     = 52000,
+	[PROJECT_WRATH]    = 35000,
+	[PROJECT_TBC]      = 24000,
+	[PROJECT_CLASSIC]  = nil,
 }
 tse.expansionItemIdFloor = expansionItemIdFloors[WOW_PROJECT_ID]
 
@@ -48,16 +62,21 @@ local function parseCommand(msg)
 	return format, exportAll
 end
 
-local function getCraftedOutputId(index)
-	local itemLink = GetTradeSkillItemLink(index)
+local function getCraftedOutputId(indexOrRecipeID)
+	local itemLink
+	if isRetail then
+		itemLink = C_TradeSkillUI.GetRecipeItemLink(indexOrRecipeID)
+	else
+		itemLink = GetTradeSkillItemLink(indexOrRecipeID)
+	end
 	if not itemLink then return nil end
 	local id = itemLink:match("item:(%d+)") or itemLink:match("enchant:(%d+)")
 	return id and tonumber(id) or nil
 end
 
-local function isCurrentExpansionRecipe(index)
+local function isCurrentExpansionRecipe(indexOrRecipeID)
 	if not tse.expansionItemIdFloor then return true end
-	local outputId = getCraftedOutputId(index)
+	local outputId = getCraftedOutputId(indexOrRecipeID)
 	if outputId == nil then return true end
 	return outputId >= tse.expansionItemIdFloor
 end
@@ -110,22 +129,37 @@ local function printHelp()
 	print("\124cff00FF00TSE:\124r '/tsexport markdown' or '/tsexport markdown current' - Markdown list")
 end
 
-local function getItemLink(index)
+local function getItemLink(indexOrRecipeID)
 	local itemLink, itemId
 
-	itemLink = GetTradeSkillItemLink(index)
+	if isRetail then
+		itemLink = C_TradeSkillUI.GetRecipeItemLink(indexOrRecipeID)
+		if itemLink then
+			itemId = itemLink:match("item:(%d+)") or itemLink:match("enchant:(%d+)")
+			if itemId then return "item=" .. tonumber(itemId) end
+		end
+		-- Fall back to the spell link for the recipe itself
+		itemLink = C_TradeSkillUI.GetRecipeLink(indexOrRecipeID)
+		if itemLink then
+			itemId = itemLink:match("spell:(%d+)")
+			if itemId then return "spell=" .. tonumber(itemId) end
+		end
+		return nil
+	end
+
+	itemLink = GetTradeSkillItemLink(indexOrRecipeID)
 	if itemLink then
 		itemId = itemLink:match("item:(%d+)") or itemLink:match("enchant:(%d+)")
 		if itemId then return "item=" .. tonumber(itemId) end
 	end
 
-	itemLink = GetTradeSkillRecipeLink(index)
+	itemLink = GetTradeSkillRecipeLink(indexOrRecipeID)
 	if itemLink then
 		itemId = itemLink:match("item:(%d+)") or itemLink:match("enchant:(%d+)")
 		if itemId then
 			return "spell=" .. tonumber(itemId)
 		else
-			print("|cffFF0000[TSE]: Unable to process entry " .. index)
+			print("|cffFF0000[TSE]: Unable to process entry " .. indexOrRecipeID)
 			if itemLink then print(itemLink:gsub('\124', '\124\124')) end
 			return nil
 		end
@@ -135,6 +169,44 @@ local function getItemLink(index)
 end
 
 local function captureRecipeData()
+	if isRetail then
+		local profInfo = C_TradeSkillUI.GetChildProfessionInfo()
+		if not profInfo or not profInfo.professionID then return false end
+
+		local skillName = profInfo.professionName or "Unknown"
+		-- Retail has no single skill rank — pass 0 (buildHeader guards with "if rank > 0")
+		local skillRank = 0
+
+		local recipeIDs = C_TradeSkillUI.GetFilteredRecipeIDs()
+		if not recipeIDs or #recipeIDs == 0 then return false end
+
+		-- GetFilteredRecipeIDs() returns recipes across ALL expansion skill lines for this
+		-- profession. Use IsRecipeInSkillLine to tag which recipes belong to the currently
+		-- open expansion (e.g. "War Within Tailoring" vs "Dragonflight Tailoring").
+		local childProfessionID = profInfo.professionID
+		local recipes = {}
+		for _, recipeID in ipairs(recipeIDs) do
+			local info = C_TradeSkillUI.GetRecipeInfo(recipeID)
+			if info and info.learned and info.name then
+				local expInfo = C_TradeSkillUI.GetProfessionInfoByRecipeID(recipeID)
+				table.insert(recipes, {
+					name               = info.name,
+					itemLink           = getItemLink(recipeID),
+					expansionName      = expInfo and expInfo.expansionName or nil,
+					isCurrentExpansion = C_TradeSkillUI.IsRecipeInSkillLine(recipeID, childProfessionID),
+				})
+			end
+		end
+
+		tse.recipeData = {
+			skillName = skillName,
+			skillRank = skillRank,
+			player    = getPlayerInfo(),
+			recipes   = recipes,
+		}
+		return true
+	end
+
 	local skillName, skillRank = GetTradeSkillLine()
 	if skillRank == 0 then return false end
 
@@ -168,15 +240,50 @@ local function buildExportText(format, scope)
 	if not tse.recipeData then return "", "" end
 	local data = tse.recipeData
 
-	local lines = {}
-	local count = 0
+	-- Collect recipes that pass the scope filter
+	local filtered = {}
 	for _, recipe in ipairs(data.recipes) do
-		if scope or recipe.isCurrentExpansion then
-			if recipe.itemLink then
-				local url = tse.wowheadBase and (tse.wowheadBase .. recipe.itemLink) or nil
-				lines[#lines + 1] = SWE.RenderRow(format, { { label = recipe.name, url = url } })
-				count = count + 1
+		if (scope or recipe.isCurrentExpansion) and recipe.itemLink then
+			table.insert(filtered, recipe)
+		end
+	end
+
+	local lines = {}
+	local count = #filtered
+
+	-- On retail, recipes carry expansionName — group by expansion with section headers.
+	-- On classic, recipes have no expansionName — emit a flat list as before.
+	local hasExpansionGroups = isRetail and filtered[1] and filtered[1].expansionName ~= nil
+
+	if hasExpansionGroups then
+		-- CSV: emit column header with Expansion column first
+		if format == "csv" then
+			lines[#lines + 1] = SWE.RenderHeader(format, { "Expansion", "Recipe" })
+		end
+
+		local currentExpansion = nil
+		for _, recipe in ipairs(filtered) do
+			local expName = recipe.expansionName or "Unknown"
+			if expName ~= currentExpansion then
+				currentExpansion = expName
+				if format == "markdown" then
+					lines[#lines + 1] = "\n## " .. expName .. "\n\n"
+				elseif format == "text" then
+					lines[#lines + 1] = "\n--- " .. expName .. " ---\n"
+				end
+				-- csv: no section header — expansion is a column value instead
 			end
+			local url = tse.wowheadBase and (tse.wowheadBase .. recipe.itemLink) or nil
+			if format == "csv" then
+				lines[#lines + 1] = SWE.RenderRow(format, { expName, { label = recipe.name, url = url } })
+			else
+				lines[#lines + 1] = SWE.RenderRow(format, { { label = recipe.name, url = url } })
+			end
+		end
+	else
+		for _, recipe in ipairs(filtered) do
+			local url = tse.wowheadBase and (tse.wowheadBase .. recipe.itemLink) or nil
+			lines[#lines + 1] = SWE.RenderRow(format, { { label = recipe.name, url = url } })
 		end
 	end
 
@@ -204,7 +311,7 @@ local function runExport(exportType, exportAll)
 				{ label = "Markdown", value = "markdown", disabled = not tse.wowheadBase },
 			},
 			defaultFormat = "text",
-			hasScope      = tse.expansionItemIdFloor ~= nil,
+			hasScope      = tse.expansionItemIdFloor ~= nil or isRetail,
 			onRefresh     = buildExportText,
 		})
 	end
@@ -216,6 +323,19 @@ end
 
 local function attachTradeSkillButton()
 	if tse.tradeSkillButton then return end
+
+	if isRetail then
+		if not ProfessionsFrame then return end
+		local button = CreateFrame("Button", nil, ProfessionsFrame, "UIPanelButtonTemplate")
+		button:SetSize(72, 18)
+		button:SetText("TSExport")
+		button:SetPoint("RIGHT", ProfessionsFrame.MaximizeMinimize, "LEFT", -2, 0)
+		button:SetScript("OnClick", function()
+			runExport(tse.lastFormat or "text", tse.lastScope ~= false)
+		end)
+		tse.tradeSkillButton = button
+		return
+	end
 
 	local button = CreateFrame("Button", nil, TradeSkillFrame, "UIPanelButtonTemplate")
 	button:SetSize(72, 18)

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
@@ -289,9 +289,14 @@ local function buildExportText(format, scope)
 			if expName ~= currentExpansion then
 				currentExpansion = expName
 				if lib == "markdown" then
-					lines[#lines + 1] = "\n## " .. expName .. "\n\n"
+					-- No leading \n — header block already ends with a blank line.
+					-- Trailing \n\n gives a blank line between the heading and its recipe list.
+					lines[#lines + 1] = "## " .. expName .. "\n\n"
 				elseif lib == "text" then
-					lines[#lines + 1] = "\n--- " .. expName .. " ---\n"
+					-- No leading \n — the blank line at the end of the header block already
+					-- provides separation before the first section; subsequent sections get
+					-- a blank line from the trailing \n of the previous recipe row.
+					lines[#lines + 1] = "--- " .. expName .. " ---\n"
 				end
 				-- csv / md-table: expansion is a column value, no section header needed
 			end

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
@@ -1,7 +1,7 @@
 -- SimpleTradeSkillExporter
 -- Author: Hamma
--- Description: Exports trade skill recipes to plain text, CSV, or Markdown format.
---              Supports all classic WoW flavors (Vanilla, TBC, Wrath, Cata, MoP).
+-- Description: Exports trade skill recipes to plain text, CSV, Markdown list, or Markdown table.
+--              Supports Retail (The War Within) and all classic WoW flavors (Vanilla, TBC, Wrath, Cata, MoP).
 --              Use /tsexport or the Export button on the tradeskill window.
 
 local addonName, tse        = ...

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
@@ -4,22 +4,22 @@
 --              Supports all classic WoW flavors (Vanilla, TBC, Wrath, Cata, MoP).
 --              Use /tsexport or the Export button on the tradeskill window.
 
-local addonName, tse = ...
-local SWE = tse.SWE -- loaded by SimpleWowExportersLib.lua via TOC
+local addonName, tse        = ...
+local SWE                   = tse.SWE -- loaded by SimpleWowExportersLib.lua via TOC
 
 -- WOW_PROJECT_* constants are only defined on their respective clients.
 -- Use numeric literals as table keys to avoid nil key errors on other clients.
 -- Values sourced from https://warcraft.wiki.gg/wiki/WOW_PROJECT_ID
-local PROJECT_MAINLINE   = 1
-local PROJECT_CLASSIC    = 2
-local PROJECT_TBC        = 5
-local PROJECT_WRATH      = 11
-local PROJECT_CATA       = 14
-local PROJECT_MISTS      = 19
+local PROJECT_MAINLINE      = 1
+local PROJECT_CLASSIC       = 2
+local PROJECT_TBC           = 5
+local PROJECT_WRATH         = 11
+local PROJECT_CATA          = 14
+local PROJECT_MISTS         = 19
 
-local isRetail = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
+local isRetail              = WOW_PROJECT_ID == WOW_PROJECT_MAINLINE
 
-local wowheadUrls = {
+local wowheadUrls           = {
 	[PROJECT_MAINLINE] = "https://www.wowhead.com/",
 	[PROJECT_MISTS]    = "https://wowhead.com/mop-classic/",
 	[PROJECT_CATA]     = "https://wowhead.com/cata/",
@@ -27,7 +27,7 @@ local wowheadUrls = {
 	[PROJECT_TBC]      = "https://wowhead.com/tbc/",
 	[PROJECT_CLASSIC]  = "https://wowhead.com/classic/",
 }
-tse.wowheadBase = wowheadUrls[WOW_PROJECT_ID]
+tse.wowheadBase             = wowheadUrls[WOW_PROJECT_ID]
 
 local expansionItemIdFloors = {
 	[PROJECT_MAINLINE] = 210000, -- The War Within
@@ -37,13 +37,20 @@ local expansionItemIdFloors = {
 	[PROJECT_TBC]      = 24000,
 	[PROJECT_CLASSIC]  = nil,
 }
-tse.expansionItemIdFloor = expansionItemIdFloors[WOW_PROJECT_ID]
+tse.expansionItemIdFloor    = expansionItemIdFloors[WOW_PROJECT_ID]
+
+-- Translates TSE format values to the lib's internal format keys.
+local function libFormat(format)
+	if format == "markdown-table" then return "md-table" end
+	return format
+end
 
 local exportWindow
 
-local validFormats = { text = true, csv = true, markdown = true }
+local validFormats = { text = true, csv = true, markdown = true, ["markdown-table"] = true }
 
 -- Examples: "csv" -> ("csv", true), "csv current" -> ("csv", false), "" -> ("text", true)
+-- "markdown table" -> ("markdown-table", true), "markdown table current" -> ("markdown-table", false)
 -- All expansions is the default. Append "current" to limit to current expansion only.
 -- Unknown format values are normalised to "text" with a warning printed to chat.
 local function parseCommand(msg)
@@ -54,6 +61,11 @@ local function parseCommand(msg)
 	if not exportAll then table.remove(parts, #parts) end
 
 	local format = parts[1] or "text"
+	-- "markdown table" is a two-word alias for "markdown-table"
+	if format == "markdown" and parts[2] == "table" then
+		format = "markdown-table"
+	end
+
 	if not validFormats[format] then
 		print("|cffFF0000[TSE]:|r Unknown format '" .. format .. "', defaulting to text.")
 		format = "text"
@@ -92,7 +104,7 @@ local function getPlayerInfo()
 end
 
 local function buildHeader(player, skillName, rank, recipeCount, exportType)
-	if exportType == "markdown" then
+	if exportType == "markdown" or exportType == "markdown-table" then
 		local h =
 			"**Player:** " ..
 			player.name .. ", Level " .. player.level .. " " .. player.race .. " " .. player.class .. "  \n" ..
@@ -101,7 +113,10 @@ local function buildHeader(player, skillName, rank, recipeCount, exportType)
 		if rank > 0 then
 			h = h .. "**" .. skillName .. ":** Skill " .. rank .. ", " .. recipeCount .. " total recipes  \n"
 		end
-		return h .. "\n"
+		if exportType == "markdown-table" then
+			return h .. "\n"
+		end
+		return h
 	elseif exportType == "csv" then
 		return ""
 	else
@@ -113,13 +128,13 @@ local function buildHeader(player, skillName, rank, recipeCount, exportType)
 		if rank > 0 then
 			h = h .. skillName .. " skill " .. rank .. ", " .. recipeCount .. " total recipes  \n"
 		end
-		return h .. "---------------------\n"
+		return h
 	end
 end
 
 local function printHelp()
 	print(
-	"\124cff00FF00TSE:\124r \124cff00FF00S\124rimple \124cff00FF00T\124rradeskill \124cff00FF00E\124rxporter - Help")
+		"\124cff00FF00TSE:\124r \124cff00FF00S\124rimple \124cff00FF00T\124rradeskill \124cff00FF00E\124rxporter - Help")
 	print("\124cff00FF00TSE:\124r Type '/tsexport help' to show this message")
 	print("\124cff00FF00TSE:\124r Open a tradeskill window, then type one of the following commands")
 	print("\124cff00FF00TSE:\124r By default, all expansions are exported")
@@ -127,6 +142,7 @@ local function printHelp()
 	print("\124cff00FF00TSE:\124r '/tsexport' or '/tsexport current' - plain text list")
 	print("\124cff00FF00TSE:\124r '/tsexport csv' or '/tsexport csv current' - Comma Separated Value list")
 	print("\124cff00FF00TSE:\124r '/tsexport markdown' or '/tsexport markdown current' - Markdown list")
+	print("\124cff00FF00TSE:\124r '/tsexport markdown table' or '/tsexport markdown table current' - Markdown table")
 end
 
 local function getItemLink(indexOrRecipeID)
@@ -239,6 +255,7 @@ local function buildExportText(format, scope)
 	tse.lastScope  = scope
 	if not tse.recipeData then return "", "" end
 	local data = tse.recipeData
+	local lib = libFormat(format)
 
 	-- Collect recipes that pass the scope filter
 	local filtered = {}
@@ -256,9 +273,9 @@ local function buildExportText(format, scope)
 	local hasExpansionGroups = isRetail and filtered[1] and filtered[1].expansionName ~= nil
 
 	if hasExpansionGroups then
-		-- CSV: emit column header with Expansion column first
-		if format == "csv" then
-			lines[#lines + 1] = SWE.RenderHeader(format, { "Expansion", "Recipe" })
+		-- csv and md-table: emit column header with Expansion column
+		if lib == "csv" or lib == "md-table" then
+			lines[#lines + 1] = SWE.RenderHeader(lib, { "Expansion", "Recipe" })
 		end
 
 		local currentExpansion = nil
@@ -266,24 +283,28 @@ local function buildExportText(format, scope)
 			local expName = recipe.expansionName or "Unknown"
 			if expName ~= currentExpansion then
 				currentExpansion = expName
-				if format == "markdown" then
+				if lib == "markdown" then
 					lines[#lines + 1] = "\n## " .. expName .. "\n\n"
-				elseif format == "text" then
+				elseif lib == "text" then
 					lines[#lines + 1] = "\n--- " .. expName .. " ---\n"
 				end
-				-- csv: no section header — expansion is a column value instead
+				-- csv / md-table: expansion is a column value, no section header needed
 			end
 			local url = tse.wowheadBase and (tse.wowheadBase .. recipe.itemLink) or nil
-			if format == "csv" then
-				lines[#lines + 1] = SWE.RenderRow(format, { expName, { label = recipe.name, url = url } })
+			if lib == "csv" or lib == "md-table" then
+				lines[#lines + 1] = SWE.RenderRow(lib, { expName, { label = recipe.name, url = url } })
 			else
-				lines[#lines + 1] = SWE.RenderRow(format, { { label = recipe.name, url = url } })
+				lines[#lines + 1] = SWE.RenderRow(lib, { { label = recipe.name, url = url } })
 			end
 		end
 	else
+		-- Classic flat list — emit column header for tabular formats
+		if lib == "csv" or lib == "md-table" then
+			lines[#lines + 1] = SWE.RenderHeader(lib, { "Recipe" })
+		end
 		for _, recipe in ipairs(filtered) do
 			local url = tse.wowheadBase and (tse.wowheadBase .. recipe.itemLink) or nil
-			lines[#lines + 1] = SWE.RenderRow(format, { { label = recipe.name, url = url } })
+			lines[#lines + 1] = SWE.RenderRow(lib, { { label = recipe.name, url = url } })
 		end
 	end
 
@@ -293,7 +314,7 @@ local function buildExportText(format, scope)
 end
 
 local function runExport(exportType, exportAll)
-	if (exportType == "csv" or exportType == "markdown") and not tse.wowheadBase then
+	if (exportType == "csv" or exportType == "markdown" or exportType == "markdown-table") and not tse.wowheadBase then
 		print("\124cffFF0000Error:\124r CSV and Markdown exports are not supported on this version of WoW.")
 		return
 	end
@@ -307,8 +328,9 @@ local function runExport(exportType, exportAll)
 		exportWindow = SWE.CreateExportWindow({
 			buttons       = {
 				{ label = "Text",     value = "text" },
-				{ label = "CSV",      value = "csv",      disabled = not tse.wowheadBase },
-				{ label = "Markdown", value = "markdown", disabled = not tse.wowheadBase },
+				{ label = "CSV",      value = "csv",            disabled = not tse.wowheadBase },
+				{ label = "MD List",  value = "markdown",       disabled = not tse.wowheadBase },
+				{ label = "MD Table", value = "markdown-table", disabled = not tse.wowheadBase },
 			},
 			defaultFormat = "text",
 			hasScope      = tse.expansionItemIdFloor ~= nil or isRetail,
@@ -329,7 +351,8 @@ local function attachTradeSkillButton()
 		local button = CreateFrame("Button", nil, ProfessionsFrame, "UIPanelButtonTemplate")
 		button:SetSize(72, 18)
 		button:SetText("TSExport")
-		button:SetPoint("RIGHT", ProfessionsFrame.MaximizeMinimize, "LEFT", -2, 0)
+		button:SetFrameLevel(ProfessionsFrame.CloseButton:GetFrameLevel())
+		button:SetPoint("LEFT", ProfessionsFrame.CraftingPage.TutorialButton, "RIGHT", 4, 0)
 		button:SetScript("OnClick", function()
 			runExport(tse.lastFormat or "text", tse.lastScope ~= false)
 		end)
@@ -355,7 +378,7 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1)
 	if event == "ADDON_LOADED" and arg1 == addonName then
 		if not tse.SWE then
 			print(
-			"\124cffFF0000[TSE] Error:\124r SimpleWowExportersLib failed to load. Ensure SimpleWowExportersLib.lua is in the addon folder.")
+				"\124cffFF0000[TSE] Error:\124r SimpleWowExportersLib failed to load. Ensure SimpleWowExportersLib.lua is in the addon folder.")
 			self:UnregisterEvent("ADDON_LOADED")
 			self:UnregisterEvent("TRADE_SKILL_SHOW")
 			return

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.lua
@@ -40,9 +40,9 @@ local expansionItemIdFloors = {
 tse.expansionItemIdFloor    = expansionItemIdFloors[WOW_PROJECT_ID]
 
 -- Translates TSE format values to the lib's internal format keys.
-local function libFormat(format)
-	if format == "markdown-table" then return "md-table" end
-	return format
+local function libFormat(formatKey)
+	if formatKey == "markdown-table" then return "md-table" end
+	return formatKey
 end
 
 local exportWindow
@@ -74,21 +74,22 @@ local function parseCommand(msg)
 	return format, exportAll
 end
 
-local function getCraftedOutputId(indexOrRecipeID)
+-- recipeRef: numeric index (classic GetTradeSkillItemLink) or recipeID (retail C_TradeSkillUI)
+local function getCraftedOutputId(recipeRef)
 	local itemLink
 	if isRetail then
-		itemLink = C_TradeSkillUI.GetRecipeItemLink(indexOrRecipeID)
+		itemLink = C_TradeSkillUI.GetRecipeItemLink(recipeRef)
 	else
-		itemLink = GetTradeSkillItemLink(indexOrRecipeID)
+		itemLink = GetTradeSkillItemLink(recipeRef)
 	end
 	if not itemLink then return nil end
 	local id = itemLink:match("item:(%d+)") or itemLink:match("enchant:(%d+)")
 	return id and tonumber(id) or nil
 end
 
-local function isCurrentExpansionRecipe(indexOrRecipeID)
+local function isCurrentExpansionRecipe(recipeRef)
 	if not tse.expansionItemIdFloor then return true end
-	local outputId = getCraftedOutputId(indexOrRecipeID)
+	local outputId = getCraftedOutputId(recipeRef)
 	if outputId == nil then return true end
 	return outputId >= tse.expansionItemIdFloor
 end
@@ -103,33 +104,33 @@ local function getPlayerInfo()
 	return { name = name, race = race, class = class, level = level, guild = guild, server = server }
 end
 
-local function buildHeader(player, skillName, rank, recipeCount, exportType)
-	if exportType == "markdown" or exportType == "markdown-table" then
-		local h =
-			"**Player:** " ..
-			player.name .. ", Level " .. player.level .. " " .. player.race .. " " .. player.class .. "  \n" ..
-			"**Guild:** " .. player.guild .. "  \n" ..
-			"**Server:** " .. player.server .. "  \n"
-		if rank > 0 then
-			h = h .. "**" .. skillName .. ":** Skill " .. rank .. ", " .. recipeCount .. " total recipes  \n"
+-- Renders the player info block. bold=true wraps field labels in ** for markdown.
+-- Markdown requires two trailing spaces before \n for a line break; plain text uses \n only.
+local function formatPlayerLine(player, bold)
+	local b = bold and "**" or ""
+	local nl = bold and "  \n" or "\n"
+	return
+		b .. "Player:" .. b .. " " ..
+		player.name .. ", Level " .. player.level .. " " .. player.race .. " " .. player.class .. nl ..
+		b .. "Guild:" .. b .. " " .. player.guild .. nl ..
+		b .. "Server:" .. b .. " " .. player.server .. nl
+end
+
+local function buildHeader(player, skillName, skillRank, recipeCount, exportType)
+	if exportType == "csv" then return "" end
+	local isMarkdown = exportType == "markdown" or exportType == "markdown-table"
+	local nl = isMarkdown and "  \n" or "\n"
+	local h = formatPlayerLine(player, isMarkdown)
+	if skillRank > 0 then
+		if isMarkdown then
+			h = h .. "**" .. skillName .. ":** Skill " .. skillRank .. ", " .. recipeCount .. " total recipes" .. nl
+		else
+			h = h .. skillName .. " skill " .. skillRank .. ", " .. recipeCount .. " total recipes" .. nl
 		end
-		if exportType == "markdown-table" then
-			return h .. "\n"
-		end
-		return h
-	elseif exportType == "csv" then
-		return ""
-	else
-		local h =
-			"Player: " ..
-			player.name .. ", Level " .. player.level .. " " .. player.race .. " " .. player.class .. "  \n" ..
-			"Guild: " .. player.guild .. "  \n" ..
-			"Server: " .. player.server .. "  \n"
-		if rank > 0 then
-			h = h .. skillName .. " skill " .. rank .. ", " .. recipeCount .. " total recipes  \n"
-		end
-		return h
 	end
+	-- Blank line between header block and recipe list for all formats
+	h = h .. "\n"
+	return h
 end
 
 local function printHelp()
@@ -145,17 +146,19 @@ local function printHelp()
 	print("\124cff00FF00TSE:\124r '/tsexport markdown table' or '/tsexport markdown table current' - Markdown table")
 end
 
-local function getItemLink(indexOrRecipeID)
+-- Returns a Wowhead URL path fragment ("item=12345" or "spell=12345") for the crafted output.
+-- recipeRef: numeric index (classic) or recipeID (retail), depending on client API.
+local function getWowheadPath(recipeRef)
 	local itemLink, itemId
 
 	if isRetail then
-		itemLink = C_TradeSkillUI.GetRecipeItemLink(indexOrRecipeID)
+		itemLink = C_TradeSkillUI.GetRecipeItemLink(recipeRef)
 		if itemLink then
 			itemId = itemLink:match("item:(%d+)") or itemLink:match("enchant:(%d+)")
 			if itemId then return "item=" .. tonumber(itemId) end
 		end
 		-- Fall back to the spell link for the recipe itself
-		itemLink = C_TradeSkillUI.GetRecipeLink(indexOrRecipeID)
+		itemLink = C_TradeSkillUI.GetRecipeLink(recipeRef)
 		if itemLink then
 			itemId = itemLink:match("spell:(%d+)")
 			if itemId then return "spell=" .. tonumber(itemId) end
@@ -163,19 +166,19 @@ local function getItemLink(indexOrRecipeID)
 		return nil
 	end
 
-	itemLink = GetTradeSkillItemLink(indexOrRecipeID)
+	itemLink = GetTradeSkillItemLink(recipeRef)
 	if itemLink then
 		itemId = itemLink:match("item:(%d+)") or itemLink:match("enchant:(%d+)")
 		if itemId then return "item=" .. tonumber(itemId) end
 	end
 
-	itemLink = GetTradeSkillRecipeLink(indexOrRecipeID)
+	itemLink = GetTradeSkillRecipeLink(recipeRef)
 	if itemLink then
 		itemId = itemLink:match("item:(%d+)") or itemLink:match("enchant:(%d+)")
 		if itemId then
 			return "spell=" .. tonumber(itemId)
 		else
-			print("|cffFF0000[TSE]: Unable to process entry " .. indexOrRecipeID)
+			print("|cffFF0000[TSE]: Unable to process entry " .. recipeRef)
 			if itemLink then print(itemLink:gsub('\124', '\124\124')) end
 			return nil
 		end
@@ -187,6 +190,9 @@ end
 local function captureRecipeData()
 	if isRetail then
 		local profInfo = C_TradeSkillUI.GetChildProfessionInfo()
+		if not profInfo or not profInfo.professionID then
+			profInfo = C_TradeSkillUI.GetBaseProfessionInfo()
+		end
 		if not profInfo or not profInfo.professionID then return false end
 
 		local skillName = profInfo.professionName or "Unknown"
@@ -207,7 +213,7 @@ local function captureRecipeData()
 				local expInfo = C_TradeSkillUI.GetProfessionInfoByRecipeID(recipeID)
 				table.insert(recipes, {
 					name               = info.name,
-					itemLink           = getItemLink(recipeID),
+					itemLink           = getWowheadPath(recipeID),
 					expansionName      = expInfo and expInfo.expansionName or nil,
 					isCurrentExpansion = C_TradeSkillUI.IsRecipeInSkillLine(recipeID, childProfessionID),
 				})
@@ -232,7 +238,7 @@ local function captureRecipeData()
 		if name and entryType ~= "header" then
 			table.insert(recipes, {
 				name               = name,
-				itemLink           = getItemLink(i),
+				itemLink           = getWowheadPath(i),
 				isCurrentExpansion = isCurrentExpansionRecipe(i),
 			})
 		end
@@ -268,9 +274,8 @@ local function buildExportText(format, scope)
 	local lines = {}
 	local count = #filtered
 
-	-- On retail, recipes carry expansionName — group by expansion with section headers.
-	-- On classic, recipes have no expansionName — emit a flat list as before.
-	local hasExpansionGroups = isRetail and filtered[1] and filtered[1].expansionName ~= nil
+	-- Retail recipes carry expansionName from GetProfessionInfoByRecipeID; classic recipes do not.
+	local hasExpansionGroups = isRetail and filtered[1] ~= nil and filtered[1].expansionName ~= nil
 
 	if hasExpansionGroups then
 		-- csv and md-table: emit column header with Expansion column
@@ -278,7 +283,7 @@ local function buildExportText(format, scope)
 			lines[#lines + 1] = SWE.RenderHeader(lib, { "Expansion", "Recipe" })
 		end
 
-		local currentExpansion = nil
+		local currentExpansion = nil -- nil sentinel: forces a section header on the first recipe
 		for _, recipe in ipairs(filtered) do
 			local expName = recipe.expansionName or "Unknown"
 			if expName ~= currentExpansion then
@@ -309,7 +314,8 @@ local function buildExportText(format, scope)
 	end
 
 	local header = buildHeader(data.player, data.skillName, data.skillRank, count, format)
-	local title  = data.skillName .. " skill " .. data.skillRank .. " - " .. count .. " recipes"
+	local skillRankSuffix = data.skillRank > 0 and (" skill " .. data.skillRank) or ""
+	local title = data.skillName .. skillRankSuffix .. " - " .. count .. " recipes"
 	return header .. table.concat(lines), title
 end
 
@@ -352,7 +358,12 @@ local function attachTradeSkillButton()
 		button:SetSize(72, 18)
 		button:SetText("TSExport")
 		button:SetFrameLevel(ProfessionsFrame.CloseButton:GetFrameLevel())
-		button:SetPoint("LEFT", ProfessionsFrame.CraftingPage.TutorialButton, "RIGHT", 4, 0)
+		local tutorialBtn = ProfessionsFrame.CraftingPage and ProfessionsFrame.CraftingPage.TutorialButton
+		if tutorialBtn then
+			button:SetPoint("LEFT", tutorialBtn, "RIGHT", 4, 0)
+		else
+			button:SetPoint("TOPRIGHT", ProfessionsFrame, "TOPRIGHT", -54, -28)
+		end
 		button:SetScript("OnClick", function()
 			runExport(tse.lastFormat or "text", tse.lastScope ~= false)
 		end)
@@ -383,8 +394,8 @@ eventFrame:SetScript("OnEvent", function(self, event, arg1)
 			self:UnregisterEvent("TRADE_SKILL_SHOW")
 			return
 		end
-		local getMetadata = (C_AddOns and C_AddOns.GetAddOnMetadata) or GetAddOnMetadata
-		local version = getMetadata and getMetadata(addonName, "Version")
+		local getAddonMetadata = (C_AddOns and C_AddOns.GetAddOnMetadata) or GetAddOnMetadata
+		local version = getAddonMetadata and getAddonMetadata(addonName, "Version")
 		SWE.RegisterAddon("SimpleTradeSkillExporter", version, "/tsexport help")
 		self:UnregisterEvent("ADDON_LOADED")
 	elseif event == "TRADE_SKILL_SHOW" then

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.toc
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.toc
@@ -1,5 +1,5 @@
 ## Interface: 50503
-## Interface-Mainline: 110107
+## Interface-Retail: 120005
 ## Interface-Mists: 50503
 ## Interface-TBC: 20505
 ## Interface-Vanilla: 11508

--- a/SimpleTradeSkillExporter/SimpleTradeSkillExporter.toc
+++ b/SimpleTradeSkillExporter/SimpleTradeSkillExporter.toc
@@ -1,4 +1,5 @@
 ## Interface: 50503
+## Interface-Mainline: 110107
 ## Interface-Mists: 50503
 ## Interface-TBC: 20505
 ## Interface-Vanilla: 11508


### PR DESCRIPTION
# TSE: Retail (The War Within) Support & Markdown Table Format

## Summary

- Adds full Retail WoW (The War Within) support to SimpleTradeSkillExporter — recipes export from all professions using the `C_TradeSkillUI` API #10 
- Retail exports group recipes by expansion with section headers (text/markdown) or an Expansion column (CSV/MD Table)
- Adds a new **Markdown Table** export format across all clients — available via the MD Table button or `/tsexport markdown table [current]`
- Export window format buttons relabelled: **Text**, **CSV**, **MD List**, **MD Table**

## Changes

### SimpleTradeSkillExporter
- Retail recipe capture via `C_TradeSkillUI`, grouped by expansion with section headers (text/markdown) or an Expansion column (CSV/MD Table)
- TSExport button added to `ProfessionsFrame` on Retail
- `WOW_PROJECT_*` constants replaced with local numeric literals to avoid nil key errors on other clients
- `## Interface-Retail: 120005` added to TOC

### SimpleGuildRosterExporter
- Plain text export header fixed — was using markdown-style line breaks

### Shared Library
- Export window scope no longer resets to `false` when switching formats